### PR TITLE
Dynamic member lookup on optional table definitions

### DIFF
--- a/Sources/StructuredQueriesCore/Optional.swift
+++ b/Sources/StructuredQueriesCore/Optional.swift
@@ -100,10 +100,12 @@ extension Optional: Table where Wrapped: Table {
       )
     }
 
-    public subscript<Q: QueryExpression>(
-      dynamicMember keyPath: KeyPath<Wrapped.TableColumns, Q>
-    ) -> Q? {
-      Wrapped.columns[keyPath: keyPath]
+    public subscript<QueryValue>(
+      dynamicMember keyPath: KeyPath<Wrapped.TableColumns, some QueryExpression<QueryValue>>
+    ) -> some QueryExpression<QueryValue?> {
+      let tmp = Wrapped.columns[keyPath: keyPath]
+      let tmp1: Optional<some QueryExpression<QueryValue>> = .some(tmp)
+      return tmp1
     }
   }
 }

--- a/Sources/StructuredQueriesCore/Optional.swift
+++ b/Sources/StructuredQueriesCore/Optional.swift
@@ -99,6 +99,12 @@ extension Optional: Table where Wrapped: Table {
         keyPath: \.[member: \Member.self, column: column._keyPath]
       )
     }
+
+    public subscript<Q: QueryExpression>(
+      dynamicMember keyPath: KeyPath<Wrapped.TableColumns, Q>
+    ) -> Q? {
+      Wrapped.columns[keyPath: keyPath]
+    }
   }
 }
 

--- a/Sources/StructuredQueriesCore/Optional.swift
+++ b/Sources/StructuredQueriesCore/Optional.swift
@@ -103,9 +103,8 @@ extension Optional: Table where Wrapped: Table {
     public subscript<QueryValue>(
       dynamicMember keyPath: KeyPath<Wrapped.TableColumns, some QueryExpression<QueryValue>>
     ) -> some QueryExpression<QueryValue?> {
-      let tmp = Wrapped.columns[keyPath: keyPath]
-      let tmp1: Optional<some QueryExpression<QueryValue>> = .some(tmp)
-      return tmp1
+      let result: (some QueryExpression<QueryValue>)? = .some(Wrapped.columns[keyPath: keyPath])
+      return result
     }
   }
 }

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -919,5 +919,71 @@ extension SnapshotTests {
         """
       }
     }
+
+    @Test func reusableHelperOnLeftJoinedTable() {
+      assertQuery(
+        RemindersList
+          .leftJoin(Reminder.all) { $0.id.eq($1.remindersListID) }
+          .where { $1.isHighPriority.ifnull(false) }
+      ) {
+        """
+        SELECT "remindersLists"."id", "remindersLists"."color", "remindersLists"."name", "reminders"."id", "reminders"."assignedUserID", "reminders"."dueDate", "reminders"."isCompleted", "reminders"."isFlagged", "reminders"."notes", "reminders"."priority", "reminders"."remindersListID", "reminders"."title"
+        FROM "remindersLists"
+        LEFT JOIN "reminders" ON ("remindersLists"."id" = "reminders"."remindersListID")
+        WHERE ifnull(("reminders"."priority" = 3), 0)
+        """
+      } results: {
+        """
+        ┌────────────────────┬────────────────────────────────────────────┐
+        │ RemindersList(     │ Reminder(                                  │
+        │   id: 1,           │   id: 3,                                   │
+        │   color: 4889071,  │   assignedUserID: nil,                     │
+        │   name: "Personal" │   dueDate: Date(2001-01-01T00:00:00.000Z), │
+        │ )                  │   isCompleted: false,                      │
+        │                    │   isFlagged: false,                        │
+        │                    │   notes: "Ask about diet",                 │
+        │                    │   priority: .high,                         │
+        │                    │   remindersListID: 1,                      │
+        │                    │   title: "Doctor appointment"              │
+        │                    │ )                                          │
+        ├────────────────────┼────────────────────────────────────────────┤
+        │ RemindersList(     │ Reminder(                                  │
+        │   id: 2,           │   id: 6,                                   │
+        │   color: 15567157, │   assignedUserID: nil,                     │
+        │   name: "Family"   │   dueDate: Date(2001-01-03T00:00:00.000Z), │
+        │ )                  │   isCompleted: false,                      │
+        │                    │   isFlagged: true,                         │
+        │                    │   notes: "",                               │
+        │                    │   priority: .high,                         │
+        │                    │   remindersListID: 2,                      │
+        │                    │   title: "Pick up kids from school"        │
+        │                    │ )                                          │
+        ├────────────────────┼────────────────────────────────────────────┤
+        │ RemindersList(     │ Reminder(                                  │
+        │   id: 2,           │   id: 8,                                   │
+        │   color: 15567157, │   assignedUserID: nil,                     │
+        │   name: "Family"   │   dueDate: Date(2001-01-05T00:00:00.000Z), │
+        │ )                  │   isCompleted: false,                      │
+        │                    │   isFlagged: false,                        │
+        │                    │   notes: "",                               │
+        │                    │   priority: .high,                         │
+        │                    │   remindersListID: 2,                      │
+        │                    │   title: "Take out trash"                  │
+        │                    │ )                                          │
+        └────────────────────┴────────────────────────────────────────────┘
+        """
+      }
+    }
   }
 }
+
+extension Reminder.TableColumns {
+  var isHighPriority: some QueryExpression<Bool> {
+    self.priority == Priority.high
+  }
+}
+//extension Reminder?.TableColumns {
+//  var isHighPriority: some QueryExpression<Bool> {
+//    #sql("\(self.priority) = \(Priority.high)")
+//  }
+//}

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -982,8 +982,3 @@ extension Reminder.TableColumns {
     self.priority == Priority.high
   }
 }
-//extension Reminder?.TableColumns {
-//  var isHighPriority: some QueryExpression<Bool> {
-//    #sql("\(self.priority) = \(Priority.high)")
-//  }
-//}


### PR DESCRIPTION
This makes it possible to use helpers that are defined on `SomeTable.TableColumns` when outer joining to the table.