### PR TITLE
Fix in GettingStarted doc

### DIFF
--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/GettingStarted.md
@@ -230,7 +230,7 @@ limits, offsets, and more. For example, we can chain onto the above query using 
          $0.priority.desc(),
          $0.title)
       }
-    // => [Reminder]
+    // => [String]
     ```
   }
   @Column {
@@ -273,7 +273,7 @@ method:
          $0.title)
       }
       .limit(10, offset: 10)
-    // => [Reminder]
+    // => [String]
     ```
   }
   @Column {


### PR DESCRIPTION
The select closure specifies $0.title so the query will decode Strings