### PR TITLE
Make asc/desc available only in order(by:) context

### DIFF
--- a/Sources/StructuredQueriesCore/Operators.swift
+++ b/Sources/StructuredQueriesCore/Operators.swift
@@ -694,7 +694,7 @@ extension QueryExpression where QueryValue == String {
   ///
   /// - Parameter collation: A collating sequence name.
   /// - Returns: An expression that is compared using the given collating sequence.
-  public func collate(_ collation: Collation) -> some QueryExpression<QueryValue> {
+  public func collate(_ collation: Collation) -> some QueryExpression<QueryValue> & OrderableExpression {
     BinaryOperator(lhs: self, operator: "COLLATE", rhs: collation)
   }
 
@@ -935,7 +935,7 @@ private struct UnaryOperator<QueryValue>: QueryExpression {
   }
 }
 
-struct BinaryOperator<QueryValue>: QueryExpression {
+struct BinaryOperator<QueryValue>: QueryExpression, OrderableExpression {
   let lhs: QueryFragment
   let `operator`: QueryFragment
   let rhs: QueryFragment

--- a/Sources/StructuredQueriesCore/Ordering.swift
+++ b/Sources/StructuredQueriesCore/Ordering.swift
@@ -1,4 +1,4 @@
-extension QueryExpression where QueryValue: QueryBindable {
+extension OrderableExpression {
   /// This expression with an ascending ordering term.
   ///
   /// - Parameter nullOrdering: `NULL`-specific ordering.
@@ -44,7 +44,7 @@ private struct OrderingTerm: QueryExpression {
   let direction: Direction
   let nullOrdering: NullOrdering?
 
-  init(base: some QueryExpression, direction: Direction, nullOrdering: NullOrdering?) {
+  init(base: some OrderableExpression, direction: Direction, nullOrdering: NullOrdering?) {
     self.base = base.queryFragment
     self.direction = direction
     self.nullOrdering = nullOrdering

--- a/Sources/StructuredQueriesCore/TableColumn.swift
+++ b/Sources/StructuredQueriesCore/TableColumn.swift
@@ -20,12 +20,18 @@ public protocol TableColumnExpression<Root, Value>: QueryExpression where Value 
   ) -> any TableColumnExpression<TableAlias<Root, Name>, Value>
 }
 
+/// An expression that can be ordered (ORDER BY xyz ASC/DESC).
+public protocol OrderableExpression {
+    var queryFragment: QueryFragment { get }
+}
+
 /// A type representing a table column.
 ///
 /// Don't create instances of this value directly. Instead, use the `@Table` and `@Column` macros to
 /// generate values of this type.
 public struct TableColumn<Root: Table, Value: QueryRepresentable & QueryBindable>:
   TableColumnExpression,
+  OrderableExpression,
   Sendable
 where Value.QueryOutput: Sendable {
   public typealias QueryValue = Value


### PR DESCRIPTION
Proof of concept for https://github.com/pointfreeco/swift-structured-queries/discussions/6#discussioncomment-12913247

As stated in the discussion thread above, .asc() and .desc() were appearing in autocorrect even in `.select {}` statements but it only makes sense in `.order {}`.

There are multiple ways to go about this, I chose the implementation that required the least amount of code changes I could come up with: func asc/desc is now defined as an extension on a new OrderableExpression protocol that TableColumn and some other selected types can conform to.