### PR TITLE
Use primary key for conflict target in upserts

### DIFF
--- a/Sources/StructuredQueriesCore/Statements/Insert.swift
+++ b/Sources/StructuredQueriesCore/Statements/Insert.swift
@@ -89,6 +89,7 @@ extension Table {
     return Insert(
       conflictResolution: conflictResolution,
       columnNames: columnNames,
+      conflictTargetColumnNames: [],
       values: .values(values),
       updates: doUpdate.map(Updates.init),
       returning: []
@@ -156,6 +157,7 @@ extension Table {
     return Insert(
       conflictResolution: conflictResolution,
       columnNames: columnNames,
+      conflictTargetColumnNames: [],
       values: .values(values),
       updates: doUpdate.map(Updates.init),
       returning: []
@@ -215,6 +217,7 @@ extension Table {
     return Insert(
       conflictResolution: conflictResolution,
       columnNames: columnNames,
+      conflictTargetColumnNames: [],
       values: .select(selection().query),
       updates: doUpdate.map(Updates.init),
       returning: []
@@ -242,6 +245,7 @@ extension Table {
     Insert(
       conflictResolution: conflictResolution,
       columnNames: [],
+      conflictTargetColumnNames: [],
       values: .default,
       updates: doUpdate.map(Updates.init),
       returning: []
@@ -317,6 +321,7 @@ extension PrimaryKeyedTable {
     return Insert(
       conflictResolution: conflictResolution,
       columnNames: columnNames,
+      conflictTargetColumnNames: [Self.columns.primaryKey.name],
       values: .values(values),
       updates: doUpdate.map(Updates.init),
       returning: []
@@ -338,10 +343,11 @@ private enum InsertValues {
 /// To learn more, see <doc:InsertStatements>.
 public struct Insert<Into: Table, Returning> {
   var conflictResolution: ConflictResolution?
-  var columnNames: [String] = []
+  var columnNames: [String]
+  var conflictTargetColumnNames: [String]
   fileprivate var values: InsertValues
   var updates: Updates<Into>?
-  var returning: [QueryFragment] = []
+  var returning: [QueryFragment]
 
   /// Adds a returning clause to an insert statement.
   ///
@@ -357,6 +363,7 @@ public struct Insert<Into: Table, Returning> {
     return Insert<Into, (repeat each QueryValue)>(
       conflictResolution: conflictResolution,
       columnNames: columnNames,
+      conflictTargetColumnNames: conflictTargetColumnNames,
       values: values,
       updates: updates,
       returning: returning
@@ -379,6 +386,7 @@ public struct Insert<Into: Table, Returning> {
     return Insert<Into, Into>(
       conflictResolution: conflictResolution,
       columnNames: columnNames,
+      conflictTargetColumnNames: conflictTargetColumnNames,
       values: values,
       updates: updates,
       returning: returning
@@ -424,7 +432,13 @@ extension Insert: Statement {
     }
 
     if let updates {
-      query.append("\(.newlineOrSpace)ON CONFLICT DO ")
+      query.append("\(.newlineOrSpace)ON CONFLICT ")// DO ")
+      if !conflictTargetColumnNames.isEmpty {
+        query.append("(")
+        query.append(conflictTargetColumnNames.map { "\(quote: $0)" }.joined(separator: ", "))
+        query.append(") ")
+      }
+      query.append("DO ")
       query.append(updates.isEmpty ? "NOTHING" : "UPDATE \(bind: updates)")
     }
     if !returning.isEmpty {

--- a/Sources/StructuredQueriesCore/Statements/Insert.swift
+++ b/Sources/StructuredQueriesCore/Statements/Insert.swift
@@ -432,7 +432,7 @@ extension Insert: Statement {
     }
 
     if let updates {
-      query.append("\(.newlineOrSpace)ON CONFLICT ")// DO ")
+      query.append("\(.newlineOrSpace)ON CONFLICT ")
       if !conflictTargetColumnNames.isEmpty {
         query.append("(")
         query.append(conflictTargetColumnNames.map { "\(quote: $0)" }.joined(separator: ", "))

--- a/Tests/StructuredQueriesTests/InsertTests.swift
+++ b/Tests/StructuredQueriesTests/InsertTests.swift
@@ -212,7 +212,7 @@ extension SnapshotTests {
         ┌────────────────────┐
         │ Tag(               │
         │   id: 5,           │
-        │   name: "personal" │
+        │   name: "business" │
         │ )                  │
         ├────────────────────┤
         │ Tag(               │
@@ -222,7 +222,7 @@ extension SnapshotTests {
         ├────────────────────┤
         │ Tag(               │
         │   id: 7,           │
-        │   name: "business" │
+        │   name: "personal" │
         │ )                  │
         └────────────────────┘
         """
@@ -332,7 +332,7 @@ extension SnapshotTests {
         ("id", "assignedUserID", "dueDate", "isCompleted", "isFlagged", "notes", "priority", "remindersListID", "title")
         VALUES
         (1, NULL, NULL, 0, 0, '', NULL, 1, 'Cash check')
-        ON CONFLICT ("id")DO UPDATE SET "assignedUserID" = "excluded"."assignedUserID", "dueDate" = "excluded"."dueDate", "isCompleted" = "excluded"."isCompleted", "isFlagged" = "excluded"."isFlagged", "notes" = "excluded"."notes", "priority" = "excluded"."priority", "remindersListID" = "excluded"."remindersListID", "title" = "excluded"."title"
+        ON CONFLICT DO UPDATE SET "assignedUserID" = "excluded"."assignedUserID", "dueDate" = "excluded"."dueDate", "isCompleted" = "excluded"."isCompleted", "isFlagged" = "excluded"."isFlagged", "notes" = "excluded"."notes", "priority" = "excluded"."priority", "remindersListID" = "excluded"."remindersListID", "title" = "excluded"."title"
         RETURNING "id", "assignedUserID", "dueDate", "isCompleted", "isFlagged", "notes", "priority", "remindersListID", "title"
         """
       }results: {
@@ -379,7 +379,7 @@ extension SnapshotTests {
         ON CONFLICT DO UPDATE SET "assignedUserID" = "excluded"."assignedUserID", "dueDate" = "excluded"."dueDate", "isCompleted" = "excluded"."isCompleted", "isFlagged" = "excluded"."isFlagged", "notes" = "excluded"."notes", "priority" = "excluded"."priority", "remindersListID" = "excluded"."remindersListID", "title" = "excluded"."title"
         RETURNING "id", "assignedUserID", "dueDate", "isCompleted", "isFlagged", "notes", "priority", "remindersListID", "title"
         """
-      } results: {
+      }results: {
         """
         ┌────────────────────────┐
         │ Reminder(              │
@@ -394,6 +394,32 @@ extension SnapshotTests {
         │   title: ""            │
         │ )                      │
         └────────────────────────┘
+        """
+      }
+    }
+
+    @Test func upsertWithoutID_OtherConflict() {
+      assertQuery(
+        RemindersList.upsert(RemindersList.Draft(name: "Personal"))
+          .returning(\.self)
+      ) {
+        """
+        INSERT INTO "remindersLists"
+        ("id", "color", "name")
+        VALUES
+        (NULL, 4889071, 'Personal')
+        ON CONFLICT DO UPDATE SET "color" = "excluded"."color", "name" = "excluded"."name"
+        RETURNING "id", "color", "name"
+        """
+      }results: {
+        """
+        ┌────────────────────┐
+        │ RemindersList(     │
+        │   id: 1,           │
+        │   color: 4889071,  │
+        │   name: "Personal" │
+        │ )                  │
+        └────────────────────┘
         """
       }
     }

--- a/Tests/StructuredQueriesTests/InsertTests.swift
+++ b/Tests/StructuredQueriesTests/InsertTests.swift
@@ -332,7 +332,7 @@ extension SnapshotTests {
         ("id", "assignedUserID", "dueDate", "isCompleted", "isFlagged", "notes", "priority", "remindersListID", "title")
         VALUES
         (1, NULL, NULL, 0, 0, '', NULL, 1, 'Cash check')
-        ON CONFLICT DO UPDATE SET "assignedUserID" = "excluded"."assignedUserID", "dueDate" = "excluded"."dueDate", "isCompleted" = "excluded"."isCompleted", "isFlagged" = "excluded"."isFlagged", "notes" = "excluded"."notes", "priority" = "excluded"."priority", "remindersListID" = "excluded"."remindersListID", "title" = "excluded"."title"
+        ON CONFLICT ("id") DO UPDATE SET "assignedUserID" = "excluded"."assignedUserID", "dueDate" = "excluded"."dueDate", "isCompleted" = "excluded"."isCompleted", "isFlagged" = "excluded"."isFlagged", "notes" = "excluded"."notes", "priority" = "excluded"."priority", "remindersListID" = "excluded"."remindersListID", "title" = "excluded"."title"
         RETURNING "id", "assignedUserID", "dueDate", "isCompleted", "isFlagged", "notes", "priority", "remindersListID", "title"
         """
       }results: {
@@ -376,7 +376,7 @@ extension SnapshotTests {
         ("id", "assignedUserID", "dueDate", "isCompleted", "isFlagged", "notes", "priority", "remindersListID", "title")
         VALUES
         (NULL, NULL, NULL, 0, 0, '', NULL, 1, '')
-        ON CONFLICT DO UPDATE SET "assignedUserID" = "excluded"."assignedUserID", "dueDate" = "excluded"."dueDate", "isCompleted" = "excluded"."isCompleted", "isFlagged" = "excluded"."isFlagged", "notes" = "excluded"."notes", "priority" = "excluded"."priority", "remindersListID" = "excluded"."remindersListID", "title" = "excluded"."title"
+        ON CONFLICT ("id") DO UPDATE SET "assignedUserID" = "excluded"."assignedUserID", "dueDate" = "excluded"."dueDate", "isCompleted" = "excluded"."isCompleted", "isFlagged" = "excluded"."isFlagged", "notes" = "excluded"."notes", "priority" = "excluded"."priority", "remindersListID" = "excluded"."remindersListID", "title" = "excluded"."title"
         RETURNING "id", "assignedUserID", "dueDate", "isCompleted", "isFlagged", "notes", "priority", "remindersListID", "title"
         """
       }results: {
@@ -408,18 +408,12 @@ extension SnapshotTests {
         ("id", "color", "name")
         VALUES
         (NULL, 4889071, 'Personal')
-        ON CONFLICT DO UPDATE SET "color" = "excluded"."color", "name" = "excluded"."name"
+        ON CONFLICT ("id") DO UPDATE SET "color" = "excluded"."color", "name" = "excluded"."name"
         RETURNING "id", "color", "name"
         """
       }results: {
         """
-        ┌────────────────────┐
-        │ RemindersList(     │
-        │   id: 1,           │
-        │   color: 4889071,  │
-        │   name: "Personal" │
-        │ )                  │
-        └────────────────────┘
+        UNIQUE constraint failed: remindersLists.name
         """
       }
     }

--- a/Tests/StructuredQueriesTests/InsertTests.swift
+++ b/Tests/StructuredQueriesTests/InsertTests.swift
@@ -332,10 +332,10 @@ extension SnapshotTests {
         ("id", "assignedUserID", "dueDate", "isCompleted", "isFlagged", "notes", "priority", "remindersListID", "title")
         VALUES
         (1, NULL, NULL, 0, 0, '', NULL, 1, 'Cash check')
-        ON CONFLICT DO UPDATE SET "assignedUserID" = "excluded"."assignedUserID", "dueDate" = "excluded"."dueDate", "isCompleted" = "excluded"."isCompleted", "isFlagged" = "excluded"."isFlagged", "notes" = "excluded"."notes", "priority" = "excluded"."priority", "remindersListID" = "excluded"."remindersListID", "title" = "excluded"."title"
+        ON CONFLICT ("id")DO UPDATE SET "assignedUserID" = "excluded"."assignedUserID", "dueDate" = "excluded"."dueDate", "isCompleted" = "excluded"."isCompleted", "isFlagged" = "excluded"."isFlagged", "notes" = "excluded"."notes", "priority" = "excluded"."priority", "remindersListID" = "excluded"."remindersListID", "title" = "excluded"."title"
         RETURNING "id", "assignedUserID", "dueDate", "isCompleted", "isFlagged", "notes", "priority", "remindersListID", "title"
         """
-      } results: {
+      }results: {
         """
         ┌────────────────────────┐
         │ Reminder(              │

--- a/Tests/StructuredQueriesTests/Support/Schema.swift
+++ b/Tests/StructuredQueriesTests/Support/Schema.swift
@@ -86,6 +86,11 @@ extension Database {
     )
     try execute(
       """
+      CREATE UNIQUE INDEX "remindersLists_name" ON "remindersLists"("name")
+      """
+    )
+    try execute(
+      """
       CREATE TABLE "reminders" (
         "id" INTEGER PRIMARY KEY AUTOINCREMENT,
         "assignedUserID" INTEGER,


### PR DESCRIPTION
Right now we do not specify any [conflict targets](https://sqlite.org/lang_upsert.html) when performing an upsert, which means _any_ kind of conflict will cause an insert. But I think for primary keyed tables in particular, we only want to perform an insert when there is a conflict on the primary key.

I think there is room here for a general discussion on upserts and conflict targets (even beyond primary keyed tables), but it does feel like for PKTs in particular we should add a conflict target.