### PR TITLE
Squash outer joined optional chaining

### DIFF
--- a/Sources/StructuredQueriesCore/Optional.swift
+++ b/Sources/StructuredQueriesCore/Optional.swift
@@ -106,6 +106,12 @@ extension Optional: Table where Wrapped: Table {
       let result: (some QueryExpression<QueryValue>)? = .some(Wrapped.columns[keyPath: keyPath])
       return result
     }
+
+    public subscript<QueryValue>(
+      dynamicMember keyPath: KeyPath<Wrapped.TableColumns, some QueryExpression<QueryValue?>>
+    ) -> some QueryExpression<QueryValue?> {
+      Wrapped.columns[keyPath: keyPath]
+    }
   }
 }
 

--- a/Tests/StructuredQueriesTests/JoinTests.swift
+++ b/Tests/StructuredQueriesTests/JoinTests.swift
@@ -35,5 +35,60 @@ extension SnapshotTests {
         """
       }
     }
+
+    @Test func outerJoinOptional() {
+      assertQuery(
+        RemindersList
+          .leftJoin(Reminder.all) { $0.id.eq($1.remindersListID) }
+          .select {
+            PriorityRow.Columns(value: $1.priority)
+          }
+      ) {
+        """
+        SELECT "reminders"."priority" AS "value"
+        FROM "remindersLists"
+        LEFT JOIN "reminders" ON ("remindersLists"."id" = "reminders"."remindersListID")
+        """
+      } results: {
+        """
+        ┌─────────────────────────┐
+        │ PriorityRow(value: nil) │
+        ├─────────────────────────┤
+        │ PriorityRow(            │
+        │   value: .medium        │
+        │ )                       │
+        ├─────────────────────────┤
+        │ PriorityRow(            │
+        │   value: .high          │
+        │ )                       │
+        ├─────────────────────────┤
+        │ PriorityRow(            │
+        │   value: .low           │
+        │ )                       │
+        ├─────────────────────────┤
+        │ PriorityRow(            │
+        │   value: .high          │
+        │ )                       │
+        ├─────────────────────────┤
+        │ PriorityRow(value: nil) │
+        ├─────────────────────────┤
+        │ PriorityRow(value: nil) │
+        ├─────────────────────────┤
+        │ PriorityRow(            │
+        │   value: .high          │
+        │ )                       │
+        ├─────────────────────────┤
+        │ PriorityRow(value: nil) │
+        ├─────────────────────────┤
+        │ PriorityRow(value: nil) │
+        └─────────────────────────┘
+        """
+      }
+    }
   }
+}
+
+@Selection
+private struct PriorityRow {
+  let value: Priority?
 }


### PR DESCRIPTION
Currently, an optional column selected from an outer join table produces additional optional nesting. Instead, let's squash this as might be expected via optional chaining in Swift.