### PR TITLE
Add case expression overload for non-optional expressions

### DIFF
--- a/Sources/StructuredQueriesCore/CaseExpression.swift
+++ b/Sources/StructuredQueriesCore/CaseExpression.swift
@@ -97,6 +97,23 @@ public struct Cases<Base, QueryValue: _OptionalProtocol>: QueryExpression {
     return cases
   }
 
+  /// Adds a `WHEN` clause to a `CASE` expression.
+  ///
+  /// - Parameters:
+  ///   - condition: A condition to test.
+  ///   - expression: A return value should the condition pass.
+  /// - Returns: A `CASE` expression builder.
+  public func when(
+    _ condition: some QueryExpression<Base>,
+    then expression: some QueryExpression<QueryValue.Wrapped>
+  ) -> Cases {
+    var cases = self
+    cases.cases.append(
+      When(predicate: condition.queryFragment, expression: expression.queryFragment).queryFragment
+    )
+    return cases
+  }
+
   /// Terminates a `CASE` expression with an `ELSE` clause.
   ///
   /// - Parameter expression: A return value should every `WHEN` condition fail.

--- a/Tests/StructuredQueriesTests/CaseTests.swift
+++ b/Tests/StructuredQueriesTests/CaseTests.swift
@@ -1,0 +1,35 @@
+import Dependencies
+import Foundation
+import InlineSnapshotTesting
+import StructuredQueries
+import StructuredQueriesSQLite
+import StructuredQueriesTestSupport
+import Testing
+
+extension SnapshotTests {
+  @Suite struct CaseTests {
+    @Test func dynamicCase() {
+      let ids = Array([2, 3, 5, 1, 4].enumerated())
+      let (first, rest) = (ids.first!, ids.dropFirst())
+      assertQuery(
+        Values(
+          rest
+            .reduce(Case(5).when(first.element, then: first.offset)) { cases, id in
+              cases.when(id.element, then: id.offset)
+            }
+            .else(0)
+        )
+      ) {
+        """
+        SELECT CASE 5 WHEN 2 THEN 0 WHEN 3 THEN 1 WHEN 5 THEN 2 WHEN 1 THEN 3 WHEN 4 THEN 4 ELSE 0 END
+        """
+      } results: {
+        """
+        ┌───┐
+        │ 2 │
+        └───┘
+        """
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes an ergonomic issue that otherwise required explicit `Optional.init`.