### PR TITLE
Improve query-representable UX

### DIFF
--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/DefiningYourSchema.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/DefiningYourSchema.md
@@ -295,14 +295,15 @@ example, suppose the `Reminder` table had an array of notes:
 
 This does not work because the `@Table` macro does not know how to encode and decode an array
 of strings into a value that SQLite understands. If you annotate this field with
-``JSONRepresentation``, then the library can encode the array of strings to a JSON string when
-storing data in the table, and decode the JSON array into a Swift array when decoding a row:
+``Swift/Decodable/JSONRepresentation``, then the library can encode the array of strings to a JSON
+string when storing data in the table, and decode the JSON array into a Swift array when decoding a
+row:
 
 ```swift
 @Table struct Reminder {
   let id: Int
   var title = ""
-  @Column(as: JSONRepresentation<[String]>.self)
+  @Column(as: [String].JSONRepresentation.self)
   var notes: [String]
 }
 ```

--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/QueryCookbook.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/QueryCookbook.md
@@ -396,19 +396,20 @@ suspiciously like a join constraint, which should give us a hint that what we ar
 quite right.
 
 Another way to do this is to use the `@Selection` macro described above
-(<doc:QueryCookbook#Custom-selections>), along with a ``JSONRepresentation`` of the collection
-of reminders you want to load for each list:
+(<doc:QueryCookbook#Custom-selections>), along with a ``Swift/Decodable/JSONRepresentation`` of the
+collection of reminders you want to load for each list:
 
 ```struct
 @Selection
 struct Row {
   let remindersList: RemindersList
-  @Column(as: JSONRepresentation<[Reminder]>.self)
+  @Column(as: [Reminder].JSONRepresentation.self)
   let reminders: [Reminder]
 }
 ```
 
-> Note: `Reminder` must conform to `Codable` to be able to use ``JSONRepresentation``.
+> Note: `Reminder` must conform to `Codable` to be able to use
+> ``Swift/Decodable/JSONRepresentation``.
 
 This allows the query to serialize the associated rows into JSON, which are then deserialized into
 a `Row` type. To construct such a query you can use the

--- a/Sources/StructuredQueriesCore/Documentation.docc/Extensions/QueryRepresentable.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Extensions/QueryRepresentable.md
@@ -16,4 +16,4 @@
 - ``Foundation/UUID/BytesRepresentation``
 - ``Foundation/UUID/LowercasedRepresentation``
 - ``Foundation/UUID/UppercasedRepresentation``
-- ``JSONRepresentation``
+- ``Swift/Decodable/JSONRepresentation``

--- a/Sources/StructuredQueriesCore/Internal/Deprecations.swift
+++ b/Sources/StructuredQueriesCore/Internal/Deprecations.swift
@@ -1,0 +1,4 @@
+// NB: Deprecated after 0.1.1:
+
+@available(*, deprecated, message: "Use 'MyCodableType.JSONRepresentation', instead.")
+public typealias JSONRepresentation<Value: Codable> = _CodableJSONRepresentation<Value>

--- a/Sources/StructuredQueriesCore/QueryRepresentable/Date+ISO8601.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/Date+ISO8601.swift
@@ -22,6 +22,10 @@ extension Date {
   }
 }
 
+extension Date? {
+  public typealias ISO8601Representation = Date.ISO8601Representation?
+}
+
 extension Date.ISO8601Representation: QueryBindable {
   public var queryBinding: QueryBinding {
     .text(queryOutput.iso8601String)

--- a/Sources/StructuredQueriesCore/QueryRepresentable/Date+JulianDay.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/Date+JulianDay.swift
@@ -22,6 +22,10 @@ extension Date {
   }
 }
 
+extension Date? {
+  public typealias JulianDayRepresentation = Date.JulianDayRepresentation?
+}
+
 extension Date.JulianDayRepresentation: QueryBindable {
   public var queryBinding: QueryBinding {
     .double(2440587.5 + queryOutput.timeIntervalSince1970 / 86400)

--- a/Sources/StructuredQueriesCore/QueryRepresentable/Date+UnixTime.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/Date+UnixTime.swift
@@ -22,6 +22,10 @@ extension Date {
   }
 }
 
+extension Date? {
+  public typealias UnixTimeRepresentation = Date.UnixTimeRepresentation?
+}
+
 extension Date.UnixTimeRepresentation: QueryBindable {
   public var queryBinding: QueryBinding {
     .int(Int64(queryOutput.timeIntervalSince1970))

--- a/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Bytes.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Bytes.swift
@@ -22,6 +22,10 @@ extension UUID {
   }
 }
 
+extension UUID? {
+  public typealias BytesRepresentation = UUID.BytesRepresentation?
+}
+
 extension UUID.BytesRepresentation: QueryBindable {
   public var queryBinding: QueryBinding {
     .blob(withUnsafeBytes(of: queryOutput.uuid, [UInt8].init))

--- a/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Lowercased.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Lowercased.swift
@@ -22,6 +22,10 @@ extension UUID {
   }
 }
 
+extension UUID? {
+  public typealias LowercasedRepresentation = UUID.LowercasedRepresentation?
+}
+
 extension UUID.LowercasedRepresentation: QueryBindable {
   public var queryBinding: QueryBinding {
     .text(queryOutput.uuidString.lowercased())

--- a/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Uppercased.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Uppercased.swift
@@ -22,6 +22,10 @@ extension UUID {
   }
 }
 
+extension UUID? {
+  public typealias UppercasedRepresentation = UUID.UppercasedRepresentation?
+}
+
 extension UUID.UppercasedRepresentation: QueryBindable {
   public var queryBinding: QueryBinding {
     .text(queryOutput.uuidString)

--- a/Sources/StructuredQueriesCore/SQLite/JSONFunctions.swift
+++ b/Sources/StructuredQueriesCore/SQLite/JSONFunctions.swift
@@ -11,7 +11,7 @@ extension QueryExpression {
   ///
   /// - Returns: An integer expression of the `json_array_length` function wrapping this expression.
   public func jsonArrayLength<Element: Codable & Sendable>() -> some QueryExpression<Int>
-  where QueryValue == JSONRepresentation<[Element]> {
+  where QueryValue == [Element].JSONRepresentation {
     QueryFunction("json_array_length", self)
   }
 }
@@ -33,7 +33,7 @@ extension QueryExpression where QueryValue: Codable & Sendable {
   public func jsonGroupArray(
     order: (some QueryExpression)? = Bool?.none,
     filter: (some QueryExpression<Bool>)? = Bool?.none
-  ) -> some QueryExpression<JSONRepresentation<[QueryValue]>> {
+  ) -> some QueryExpression<[QueryValue].JSONRepresentation> {
     AggregateFunction("json_group_array", self, order: order, filter: filter)
   }
 }
@@ -91,7 +91,7 @@ extension PrimaryKeyedTableDefinition where QueryValue: Codable & Sendable {
   public func jsonGroupArray(
     order: (some QueryExpression)? = Bool?.none,
     filter: (some QueryExpression<Bool>)? = Bool?.none
-  ) -> some QueryExpression<JSONRepresentation<[QueryValue]>> {
+  ) -> some QueryExpression<[QueryValue].JSONRepresentation> {
     jsonObject.jsonGroupArray(order: order, filter: filter)
   }
 
@@ -111,9 +111,9 @@ extension PrimaryKeyedTableDefinition where QueryValue: Codable & Sendable {
         if let optionalType = T.self as? any _OptionalProtocol.Type {
           return isOptionalJSONRepresentation(optionalType)
         } else if isOptional {
-          return TableColumn.QueryValue.self == JSONRepresentation<T>?.self
+          return TableColumn.QueryValue.self == T.JSONRepresentation?.self
         } else {
-          return Value.self == JSONRepresentation<T>.self
+          return Value.self == T.JSONRepresentation.self
         }
       }
 

--- a/Tests/StructuredQueriesTests/DecodingTests.swift
+++ b/Tests/StructuredQueriesTests/DecodingTests.swift
@@ -154,7 +154,7 @@ extension SnapshotTests {
             """
             '{"id":1,"name":"Blob"}'
             """,
-            as: JSONRepresentation<User>.self
+            as: User.JSONRepresentation.self
           )
         }
       ) {
@@ -189,7 +189,7 @@ extension SnapshotTests {
             """
             '{"user_id":1,"user_name":"Blob"}'
             """,
-            as: JSONRepresentation<User>.self
+            as: User.JSONRepresentation.self
           )
         }
       ) {

--- a/Tests/StructuredQueriesTests/JSONFunctionsTests.swift
+++ b/Tests/StructuredQueriesTests/JSONFunctionsTests.swift
@@ -274,13 +274,13 @@ extension SnapshotTests {
 private struct ReminderRow {
   let assignedUser: User?
   let reminder: Reminder
-  @Column(as: JSONRepresentation<[Tag]>.self)
+  @Column(as: [Tag].JSONRepresentation.self)
   let tags: [Tag]
 }
 
 @Selection
 private struct RemindersListRow {
   let remindersList: RemindersList
-  @Column(as: JSONRepresentation<[Reminder]>.self)
+  @Column(as: [Reminder].JSONRepresentation.self)
   let reminders: [Reminder]
 }

--- a/Tests/StructuredQueriesTests/KitchenSinkTests.swift
+++ b/Tests/StructuredQueriesTests/KitchenSinkTests.swift
@@ -5,15 +5,6 @@ import StructuredQueries
 import StructuredQueriesSQLite
 import Testing
 
-/*
- TODO: split json association tests into own suite with custom schema
- * exercise Bool? path
- * exercise Data/UUID path with JSON
- * exercise dates
- * exercise JSONRepresentation field (such as [String] notes)
- * exercise path that removes the NULL filter to see how that can come up
- */
-
 extension SnapshotTests {
   @MainActor
   @Suite struct KitchenSinkTests {
@@ -336,8 +327,8 @@ private struct KitchenSink: Codable {
   var julianDayDate: Date
   @Column(as: Date.JulianDayRepresentation?.self)
   var optionalJulianDayDate: Date?
-  @Column(as: JSONRepresentation<[String]>.self)
+  @Column(as: [String].JSONRepresentation.self)
   var jsonArray: [String]
-  @Column(as: JSONRepresentation<[String]>?.self)
+  @Column(as: [String].JSONRepresentation?.self)
   var optionalJSONArray: [String]?
 }

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -1018,7 +1018,7 @@ extension SnapshotTests {
         of:
           VecExample
           .where { _ in
-            #sql("sample_embedding match \(#bind(xs, as: JSONRepresentation.self))")
+            #sql("sample_embedding match \(#bind(xs, as: [Double].JSONRepresentation.self))")
           }
           .order(by: \.distance)
           .limit(2),


### PR DESCRIPTION
Currently, the various query representable wrappers must be used a very specific way when dealing with optionals, where the optional must be on the representation type, not the type being represented:

```swift
@Column(as: Date.ISO8601Representation?.self)  // ✅
var date: Date?

@Column(as: Date?.ISO8601Representation.self)  // ❌
var date: Date?
```

This PR adds a few helper type aliases to address this issue, so both now compile and do the right thing:

```swift
@Column(as: Date.ISO8601Representation?.self)  // ✅
var date: Date?

@Column(as: Date?.ISO8601Representation.self)  // ✅
var date: Date?
```

It also renames `JSONRepresentation` to `Codable.JSONRepresentation`, deprecating the former spelling. This also allows the optionality to be placed either place:

```swift
@Column(as: JSONRepresentation<Notes>?.self)  // ⚠️
var notes: Notes?

@Column(as: JSONRepresentation<Notes?>.self)  // ❌
var notes: Notes?

@Column(as: Notes.JSONRepresentation?.self)   // ✅
var notes: Notes?

@Column(as: Notes?.JSONRepresentation.self)   // ✅
var notes: Notes?
```