### PR TITLE
Synthesize `LosslessStringConvertible` `QueryBindable` conformances

### DIFF
--- a/Sources/StructuredQueriesCore/QueryBindable.swift
+++ b/Sources/StructuredQueriesCore/QueryBindable.swift
@@ -102,6 +102,10 @@ extension DefaultStringInterpolation {
   }
 }
 
+extension QueryBindable where Self: LosslessStringConvertible {
+  public var queryBinding: QueryBinding { description.queryBinding }
+}
+
 extension QueryBindable where Self: RawRepresentable, RawValue: QueryBindable {
   public var queryBinding: QueryBinding { rawValue.queryBinding }
 }

--- a/Sources/StructuredQueriesCore/QueryDecodable.swift
+++ b/Sources/StructuredQueriesCore/QueryDecodable.swift
@@ -138,6 +138,17 @@ extension UInt64: QueryDecodable {
   }
 }
 
+extension QueryDecodable where Self: LosslessStringConvertible {
+  @inlinable
+  public init(decoder: inout some QueryDecoder) throws {
+    guard let losslessStringConvertible = try Self(String(decoder: &decoder))
+    else {
+      throw DataCorruptedError()
+    }
+    self = losslessStringConvertible
+  }
+}
+
 extension QueryDecodable where Self: RawRepresentable, RawValue: QueryDecodable {
   @inlinable
   public init(decoder: inout some QueryDecoder) throws {

--- a/Tests/StructuredQueriesTests/DecodingTests.swift
+++ b/Tests/StructuredQueriesTests/DecodingTests.swift
@@ -39,6 +39,22 @@ extension SnapshotTests {
       #expect(bytes == [0xDE, 0xAD, 0xBE, 0xEF])
     }
 
+    @Test func losslessStringConvertible() throws {
+      struct Email: Equatable, LosslessStringConvertible, QueryBindable {
+        var description: String
+
+        init?(_ description: String) {
+          self.description = description
+        }
+      }
+      #expect(
+        try db.execute(
+          SimpleSelect { #sql("'support@pointfree.co'", as: Email.self) }
+        )
+        .first == Email("support@pointfree.co")
+      )
+    }
+
     @Test func rawRepresentable() throws {
       enum Priority: Int, QueryBindable {
         case low = 1


### PR DESCRIPTION
This commit makes it trivial to conform `LosslessStringConvertible` types to `QueryBindable`.