### PR TITLE
Add test demonstrating unexpected json_group_array behavior with composite primary key

### DIFF
--- a/Tests/StructuredQueriesTests/JSONFunctionsTests.swift
+++ b/Tests/StructuredQueriesTests/JSONFunctionsTests.swift
@@ -267,6 +267,30 @@ extension SnapshotTests {
         """
       }
     }
+
+    // This test is showing a missing feature
+    @Test func jsonGroupArrayMultiplePrimaryKeys() {
+      assertQuery(
+        Reminder
+          .join(ReminderTag.all) { $0.id.eq($1.reminderID) }
+          .select {
+            ReminderTagList.Columns(
+              reminder: $0,
+              tags: $1.jsonGroupArray()
+            )
+          }
+      ) {
+        """
+        SELECT "reminders"."id", "reminders"."assignedUserID", "reminders"."dueDate", "reminders"."isCompleted", "reminders"."isFlagged", "reminders"."notes", "reminders"."priority", "reminders"."remindersListID", "reminders"."title" AS "reminder", json_group_array("remindersTags"."reminderID", "remindersTags"."tagID") AS "tags"
+        FROM "reminders"
+        JOIN "remindersTags" ON ("reminders"."id" = "remindersTags"."reminderID")
+        """
+      } results: {
+        """
+        wrong number of arguments to function json_group_array()
+        """
+      }
+    }
   }
 }
 
@@ -283,4 +307,11 @@ private struct RemindersListRow {
   let remindersList: RemindersList
   @Column(as: [Reminder].JSONRepresentation.self)
   let reminders: [Reminder]
+}
+
+@Selection
+struct ReminderTagList {
+  let reminder: Reminder
+  @Column(as: [ReminderTag].JSONRepresentation.self)
+  let tags: [ReminderTag]
 }

--- a/Tests/StructuredQueriesTests/Support/Schema.swift
+++ b/Tests/StructuredQueriesTests/Support/Schema.swift
@@ -61,7 +61,7 @@ struct Tag: Codable, Equatable, Identifiable {
 }
 
 @Table("remindersTags")
-struct ReminderTag: Equatable {
+struct ReminderTag: Equatable, Codable {
   let reminderID: Int
   let tagID: Int
 }


### PR DESCRIPTION
This test highlights an issue where `json_group_array` does not behave as expected when used with a table that has a composite primary key. It serves as a baseline to illustrate the problem before implementing a fix.

slack discussion: https://pointfreecommunity.slack.com/archives/C08J4DTE0TC/p1746410694694659?thread_ts=1746404626.514169&cid=C08J4DTE0TC