### PR TITLE
feat: add databaseInitialized attribute to @Column macro to force optional on Draft properties

### DIFF
--- a/Sources/StructuredQueries/Macros.swift
+++ b/Sources/StructuredQueries/Macros.swift
@@ -34,11 +34,13 @@ public macro Table(_ name: String? = nil) =
 ///   - representableType: A type that represents the property type in a query expression. For types
 ///     that don't have a single representation in SQL, like `Date` and `UUID`.
 ///   - primaryKey: The column is its table's auto-incrementing primary key.
+///   - databaseInitialized: The column has a default value and is not needed in an insert statement.
 @attached(accessor, names: named(willSet))
 public macro Column(
   _ name: String? = nil,
   as representableType: (any QueryRepresentable.Type)? = nil,
-  primaryKey: Bool = false
+  primaryKey: Bool? = nil,
+  databaseInitialized: Bool? = nil
 ) =
   #externalMacro(
     module: "StructuredQueriesMacros",

--- a/Sources/StructuredQueriesMacros/Internal/PatternBindingSyntax.swift
+++ b/Sources/StructuredQueriesMacros/Internal/PatternBindingSyntax.swift
@@ -37,4 +37,13 @@ extension PatternBindingSyntax {
     optionalized.typeAnnotation?.type = optionalType
     return optionalized
   }
+
+  func isOptional() -> Bool {
+    // x: Optional<T> or x: T?
+    if self.typeAnnotation?.type.isOptionalType == true { return true }
+    // Missing cases
+    // x = Optional<T>.some(_)
+    // x = fnReturningOptionalType()
+    return false
+  }
 }


### PR DESCRIPTION
Discussed briefly here: https://github.com/pointfreeco/swift-structured-queries/discussions/30

## Context

Let's say I have a table with a default value:

```sql
CREATE TABLE my_table (
  created_at INTEGER DEFAULT(unixepoch()) NOT NULL
);
```

and the swift type would be:

```swift
@Table("my_table")
struct MyTable {
  @Column("created_at", as: Date.UnixTimeRepresentation.self)
  let createdAt: Date
}
```

The Draft API is a pretty nice way to insert a row on this table, but at the moment I need to pass a `Date` like so:

```swift
let draft = MyTable.Draft(createdAt: Date())
```

Would be great if I could annotate the property so the `createdAt` becomes optional on `MyTable.Draft`, similar to the `@Column(primaryKey: true)` macro. So I can use it like so:

```swift
let draft = MyTable.Draft()
```

One idea is to extend the `@Column` to accept a boolean and use it to decide if the generated property on Draft is optional or not, e.g.: `databaseInitialized: Bool` (@mbrandonw suggestion)

```swift
@Table("my_table")
struct MyTable {
  @Column("created_at", as: Date.UnixTimeRepresentation.self, databaseInitialized: true)
  let createdAt: Date
}
```

## Implementation

To decide if a non-optional property should become optional in the Draft type, I did the following mapping:

```
 isPrimaryKey &&  databaseInitialized -> Optionalize Draft
!isPrimaryKey &&  databaseInitialized -> Optionalize Draft
 isPrimaryKey && !databaseInitialized -> Inherit
!isPrimaryKey && !databaseInitialized -> Inherit

// Note: isPrimaryKey considering both, the `id` property without the `primaryKey: false`, and a property with `primaryKey: true`
```

There are some invalid cases, so I added error diagnostics to them:

```
Invalid-1. When databaseInitialized is not literal true or false, show error:
@Column(databaseInitialized: nil) -> Error: "Argument 'databaseInitialized' must be a boolean literal"

Invalid-2. `databeseInitialized: true` attached on an optional property. Note: I'm checking other types of optional binding too, not just the one in the example below.
@Column(databaseInitialized: true) 
var foo: String? -> Error: "Can't use `databaseInitialized: true` on an optional property"
```

And there are some redundant cases. I added a warning diagnostics to those:

```
Redundant-1. When both primaryKey and databaseInitialized are true
@Column(primaryKey: true, databaseInitialized: true) -> Warning: "'databaseInitialized: true' is redundant with 'primaryKey: true'"

Redundant-2. When databaseInitialized is true on an `id` without `primaryKey: false`
@Column(databaseInitialized: true) -> Warning: "'databaseInitialized: true' is redundant for primary keys'"
let id: Int

Redundant-3. When both databaseInitialized and primaryKey are false
@Column(primaryKey: false, databaseInitialized: false) -> Warning "'databaseInitialized: false' is redundant with 'primaryKey: false'"

Redundant-4. When databaseInitialized is false on a regular property
@Column(databaseInitialized: false) -> Warning "'databaseInitialized: false' is redundant for non primary keys"
var foo: String
```

I added tests for all those cases

## Other Changes

### Updated primaryKey attribute type and default value

I had to update the attribute `primaryKey: Bool = false` to `primaryKey: Bool? = nil` because if I happen to have an `id: String` that should be initialized by the application (and not the database), then following code would behave in a way I'm not expecting:

```swift
@Column(databaseInitialized: false) // Previously, this would set primaryKey to false
let id: String
```

I'm doing the same for `databaseInitialized`, the attribute's argument is `databaseInitialized: Bool? = nil` so we don't implicitly force any behavior. 

### Force removing of `databaseInitialized` attribute from the Draft type

When creating the Draft type, it was inheriting the `@Column` attribute with `databaseInitialized` which caused all sorts of issues, so I had to add some changes to prevent the Draft property to inherit the `databaseInitialized` attribute

### Print warning diagnostics and still run the macro

Previously, any diagnostic would prevent the macro generation, now it only stops when there is an `error` diagnostic, if there are warning diagnostics, it sill generates the extra swift code
