### PR TITLE
Fix anchor link in QueryCookbook.md

### DIFF
--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/QueryCookbook.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/QueryCookbook.md
@@ -12,7 +12,7 @@ large and complex queries.
 * [Reusable column queries](#Reusable-column-queries)
 * [Default scopes](#Default-scopes)
 * [Custom selections](#Custom-selections)
-* [Pre-loading associations with JSON](#Pre-loading-associations-with-json)
+* [Pre-loading associations with JSON](#Pre-loading-associations-with-JSON)
 
 ### Reusable table queries
 


### PR DESCRIPTION
This PR fixes an issue where the link to the section “Pre-loading associations with JSON” in the QueryCookBook was broken due to a case mismatch.