### PR TITLE
Use StructuredQueriesCore module name in macro expansions.

### DIFF
--- a/Sources/StructuredQueriesCore/PrimaryKeyed.swift
+++ b/Sources/StructuredQueriesCore/PrimaryKeyed.swift
@@ -9,8 +9,7 @@ public protocol PrimaryKeyedTable: Table where TableColumns: PrimaryKeyedTableDe
 // A type representing a draft to be saved to a table with a primary key.
 public protocol TableDraft: Table {
   /// A type that represents the table with a primary key.
-  associatedtype PrimaryTable: StructuredQueriesCore.PrimaryKeyedTable
-  where PrimaryTable.Draft == Self
+  associatedtype PrimaryTable: PrimaryKeyedTable where PrimaryTable.Draft == Self
 
   /// Creates a draft from a primary keyed table.
   init(_ primaryTable: PrimaryTable)

--- a/Sources/StructuredQueriesCore/Seeds.swift
+++ b/Sources/StructuredQueriesCore/Seeds.swift
@@ -92,7 +92,7 @@ public struct Seeds: Sequence {
 
         return insertBatch(firstType)
       } else {
-        func insertBatch<T: StructuredQueriesCore.Table>(_: T.Type) -> SQLQueryExpression<Void> {
+        func insertBatch<T: Table>(_: T.Type) -> SQLQueryExpression<Void> {
           let batch = Array(seeds.lazy.prefix { $0 is T }.compactMap { $0 as? T })
           defer { seeds.removeFirst(batch.count) }
           return SQLQueryExpression(T.insert(batch))

--- a/Sources/StructuredQueriesMacros/BindMacro.swift
+++ b/Sources/StructuredQueriesMacros/BindMacro.swift
@@ -9,6 +9,6 @@ public enum BindMacro: ExpressionMacro {
   ) -> ExprSyntax {
     guard let argument = node.arguments.first?.expression else { fatalError() }
     let `as` = node.arguments.dropFirst().first
-    return "StructuredQueries.BindQueryExpression(\(argument)\(raw: `as`.map { ", \($0)" } ?? ""))"
+    return "\(moduleName).BindQueryExpression(\(argument)\(raw: `as`.map { ", \($0)" } ?? ""))"
   }
 }

--- a/Sources/StructuredQueriesMacros/Internal/Support.swift
+++ b/Sources/StructuredQueriesMacros/Internal/Support.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-let moduleName: TokenSyntax = "StructuredQueries"
+let moduleName: TokenSyntax = "StructuredQueriesCore"
 
 extension String {
   func trimmingBackticks() -> String {

--- a/Sources/StructuredQueriesMacros/SQLMacro.swift
+++ b/Sources/StructuredQueriesMacros/SQLMacro.swift
@@ -207,6 +207,6 @@ public enum SQLMacro: ExpressionMacro {
         )
       )
     }
-    return "StructuredQueries.SQLQueryExpression(\(argument))"
+    return "\(moduleName).SQLQueryExpression(\(argument))"
   }
 }

--- a/Tests/StructuredQueriesMacrosTests/BindMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/BindMacroTests.swift
@@ -12,7 +12,7 @@ extension SnapshotTests {
         """#
       } expansion: {
         #"""
-        \(date) < StructuredQueries.BindQueryExpression(Date())
+        \(date) < StructuredQueriesCore.BindQueryExpression(Date())
         """#
       }
     }
@@ -24,7 +24,7 @@ extension SnapshotTests {
         """#
       } expansion: {
         #"""
-        \(date) < StructuredQueries.BindQueryExpression(Date(), as: Date.ISO8601Representation.self)
+        \(date) < StructuredQueriesCore.BindQueryExpression(Date(), as: Date.ISO8601Representation.self)
         """#
       }
     }

--- a/Tests/StructuredQueriesMacrosTests/SQLMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/SQLMacroTests.swift
@@ -12,7 +12,7 @@ extension SnapshotTests {
         """
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression("CURRENT_TIMESTAMP")
+        StructuredQueriesCore.SQLQueryExpression("CURRENT_TIMESTAMP")
         """
       }
     }
@@ -90,7 +90,7 @@ extension SnapshotTests {
         """
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression("'('")
+        StructuredQueriesCore.SQLQueryExpression("'('")
         """
       }
       assertMacro {
@@ -99,7 +99,7 @@ extension SnapshotTests {
         """
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression("[it's fine]")
+        StructuredQueriesCore.SQLQueryExpression("[it's fine]")
         """
       }
     }
@@ -169,7 +169,7 @@ extension SnapshotTests {
         """
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression(#""text" = 'hello?'"#)
+        StructuredQueriesCore.SQLQueryExpression(#""text" = 'hello?'"#)
         """
       }
       assertMacro {
@@ -178,7 +178,7 @@ extension SnapshotTests {
         """
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression(#""text" = 'hello?1'"#)
+        StructuredQueriesCore.SQLQueryExpression(#""text" = 'hello?1'"#)
         """
       }
       assertMacro {
@@ -187,7 +187,7 @@ extension SnapshotTests {
         """
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression(#""text" = 'hello:hi'"#)
+        StructuredQueriesCore.SQLQueryExpression(#""text" = 'hello:hi'"#)
         """
       }
       assertMacro {
@@ -196,7 +196,7 @@ extension SnapshotTests {
         """
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression(#""text" = 'hello@hi'"#)
+        StructuredQueriesCore.SQLQueryExpression(#""text" = 'hello@hi'"#)
         """
       }
       assertMacro {
@@ -205,7 +205,7 @@ extension SnapshotTests {
         """
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression(#""text" = 'hello$hi'"#)
+        StructuredQueriesCore.SQLQueryExpression(#""text" = 'hello$hi'"#)
         """
       }
     }
@@ -228,7 +228,7 @@ extension SnapshotTests {
         """#
       } expansion: {
         #"""
-        StructuredQueries.SQLQueryExpression("'\(raw: 42)'")
+        StructuredQueriesCore.SQLQueryExpression("'\(raw: 42)'")
         """#
       }
     }
@@ -240,7 +240,7 @@ extension SnapshotTests {
         """#
       } expansion: {
         #"""
-        StructuredQueries.SQLQueryExpression("'\(raw: 42)'")
+        StructuredQueriesCore.SQLQueryExpression("'\(raw: 42)'")
         """#
       }
     }
@@ -252,7 +252,7 @@ extension SnapshotTests {
         """#
       } expansion: {
         #"""
-        StructuredQueries.SQLQueryExpression("\($0.dueDate) < date('now', '-\(raw: monthsAgo) months')")
+        StructuredQueriesCore.SQLQueryExpression("\($0.dueDate) < date('now', '-\(raw: monthsAgo) months')")
         """#
       }
     }
@@ -264,7 +264,7 @@ extension SnapshotTests {
         """#
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression("''")
+        StructuredQueriesCore.SQLQueryExpression("''")
         """
       }
       assertMacro {
@@ -277,7 +277,7 @@ extension SnapshotTests {
         """#
       } expansion: {
         #"""
-        StructuredQueries.SQLQueryExpression(
+        StructuredQueriesCore.SQLQueryExpression(
           """
           ""
           """)
@@ -289,7 +289,7 @@ extension SnapshotTests {
         """#
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression("[]")
+        StructuredQueriesCore.SQLQueryExpression("[]")
         """
       }
     }
@@ -305,7 +305,7 @@ extension SnapshotTests {
         """#
       } expansion: {
         #"""
-        StructuredQueries.SQLQueryExpression(
+        StructuredQueriesCore.SQLQueryExpression(
           """
           SELECT 1 AS "a ""real"" one"
           """)
@@ -356,7 +356,7 @@ extension SnapshotTests {
         """
       } expansion: {
         """
-        StructuredQueries.SQLQueryExpression("json_extract(notes, '$.body')")
+        StructuredQueriesCore.SQLQueryExpression("json_extract(notes, '$.body')")
         """
       }
     }

--- a/Tests/StructuredQueriesMacrosTests/SelectionMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/SelectionMacroTests.swift
@@ -20,20 +20,20 @@ extension SnapshotTests {
           let team: Team
         }
 
-        extension PlayerAndTeam: StructuredQueries.QueryRepresentable {
-          public struct Columns: StructuredQueries.QueryExpression {
+        extension PlayerAndTeam: StructuredQueriesCore.QueryRepresentable {
+          public struct Columns: StructuredQueriesCore.QueryExpression {
             public typealias QueryValue = PlayerAndTeam
-            public let queryFragment: StructuredQueries.QueryFragment
+            public let queryFragment: StructuredQueriesCore.QueryFragment
             public init(
-              player: some StructuredQueries.QueryExpression<Player>,
-              team: some StructuredQueries.QueryExpression<Team>
+              player: some StructuredQueriesCore.QueryExpression<Player>,
+              team: some StructuredQueriesCore.QueryExpression<Team>
             ) {
               self.queryFragment = """
               \(player.queryFragment) AS "player", \(team.queryFragment) AS "team"
               """
             }
           }
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let player = try decoder.decode(Player.self)
             let team = try decoder.decode(Team.self)
             guard let player else {
@@ -82,20 +82,20 @@ extension SnapshotTests {
           var listTitle: String?
         }
 
-        extension ReminderTitleAndListTitle: StructuredQueries.QueryRepresentable {
-          public struct Columns: StructuredQueries.QueryExpression {
+        extension ReminderTitleAndListTitle: StructuredQueriesCore.QueryRepresentable {
+          public struct Columns: StructuredQueriesCore.QueryExpression {
             public typealias QueryValue = ReminderTitleAndListTitle
-            public let queryFragment: StructuredQueries.QueryFragment
+            public let queryFragment: StructuredQueriesCore.QueryFragment
             public init(
-              reminderTitle: some StructuredQueries.QueryExpression<String>,
-              listTitle: some StructuredQueries.QueryExpression<String?>
+              reminderTitle: some StructuredQueriesCore.QueryExpression<String>,
+              listTitle: some StructuredQueriesCore.QueryExpression<String?>
             ) {
               self.queryFragment = """
               \(reminderTitle.queryFragment) AS "reminderTitle", \(listTitle.queryFragment) AS "listTitle"
               """
             }
           }
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let reminderTitle = try decoder.decode(String.self)
             let listTitle = try decoder.decode(String.self)
             guard let reminderTitle else {
@@ -123,19 +123,19 @@ extension SnapshotTests {
           var date: Date
         }
 
-        extension ReminderDate: StructuredQueries.QueryRepresentable {
-          public struct Columns: StructuredQueries.QueryExpression {
+        extension ReminderDate: StructuredQueriesCore.QueryRepresentable {
+          public struct Columns: StructuredQueriesCore.QueryExpression {
             public typealias QueryValue = ReminderDate
-            public let queryFragment: StructuredQueries.QueryFragment
+            public let queryFragment: StructuredQueriesCore.QueryFragment
             public init(
-              date: some StructuredQueries.QueryExpression<Date.ISO8601Representation>
+              date: some StructuredQueriesCore.QueryExpression<Date.ISO8601Representation>
             ) {
               self.queryFragment = """
               \(date.queryFragment) AS "date"
               """
             }
           }
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let date = try decoder.decode(Date.ISO8601Representation.self)
             guard let date else {
               throw QueryDecodingError.missingRequiredColumn
@@ -178,19 +178,19 @@ extension SnapshotTests {
           var date: Date
         }
 
-        extension ReminderDate: StructuredQueries.QueryRepresentable {
-          public struct Columns: StructuredQueries.QueryExpression {
+        extension ReminderDate: StructuredQueriesCore.QueryRepresentable {
+          public struct Columns: StructuredQueriesCore.QueryExpression {
             public typealias QueryValue = ReminderDate
-            public let queryFragment: StructuredQueries.QueryFragment
+            public let queryFragment: StructuredQueriesCore.QueryFragment
             public init(
-              date: some StructuredQueries.QueryExpression<Date.ISO8601Representation>
+              date: some StructuredQueriesCore.QueryExpression<Date.ISO8601Representation>
             ) {
               self.queryFragment = """
               \(date.queryFragment) AS "date"
               """
             }
           }
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let date = try decoder.decode(Date.ISO8601Representation.self)
             guard let date else {
               throw QueryDecodingError.missingRequiredColumn

--- a/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
@@ -19,17 +19,17 @@ extension SnapshotTests {
           var bar: Int
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(Int.self)
             guard let bar else {
               throw QueryDecodingError.missingRequiredColumn
@@ -65,37 +65,37 @@ extension SnapshotTests {
           var age: Int
         }
 
-        extension User: StructuredQueries.Table, StructuredQueries.PrimaryKeyedTable {
-          public struct TableColumns: StructuredQueries.TableDefinition, StructuredQueries.PrimaryKeyedTableDefinition {
+        extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
             public typealias QueryValue = User
-            public let id = StructuredQueries.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
-            public let email = StructuredQueries.TableColumn<QueryValue, String?>("email", keyPath: \QueryValue.email)
-            public let age = StructuredQueries.TableColumn<QueryValue, Int>("age", keyPath: \QueryValue.age)
-            public var primaryKey: StructuredQueries.TableColumn<QueryValue, Int> {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
+            public let email = StructuredQueriesCore.TableColumn<QueryValue, String?>("email", keyPath: \QueryValue.email)
+            public let age = StructuredQueriesCore.TableColumn<QueryValue, Int>("age", keyPath: \QueryValue.age)
+            public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, Int> {
               self.id
             }
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id, QueryValue.columns.email, QueryValue.columns.age]
             }
           }
-          public struct Draft: StructuredQueries.TableDraft {
+          public struct Draft: StructuredQueriesCore.TableDraft {
             public typealias PrimaryTable = User
             @Column(primaryKey: false)
             let id: /* TODO: UUID */ Int?
             var email: String?
             var age: Int
-            public struct TableColumns: StructuredQueries.TableDefinition {
+            public struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = User.Draft
-              public let id = StructuredQueries.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
-              public let email = StructuredQueries.TableColumn<QueryValue, String?>("email", keyPath: \QueryValue.email)
-              public let age = StructuredQueries.TableColumn<QueryValue, Int>("age", keyPath: \QueryValue.age)
-              public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+              public let id = StructuredQueriesCore.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
+              public let email = StructuredQueriesCore.TableColumn<QueryValue, String?>("email", keyPath: \QueryValue.email)
+              public let age = StructuredQueriesCore.TableColumn<QueryValue, Int>("age", keyPath: \QueryValue.age)
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
                 [QueryValue.columns.id, QueryValue.columns.email, QueryValue.columns.age]
               }
             }
             public static let columns = TableColumns()
             public static let tableName = User.tableName
-            public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+            public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               self.id = try decoder.decode(Int.self)
               self.email = try decoder.decode(String.self)
               let age = try decoder.decode(Int.self)
@@ -121,7 +121,7 @@ extension SnapshotTests {
           }
           public static let columns = TableColumns()
           public static let tableName = "users"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(Int.self)
             self.email = try decoder.decode(String.self)
             let age = try decoder.decode(Int.self)
@@ -153,17 +153,17 @@ extension SnapshotTests {
           var bar: Int
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foo"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(Int.self)
             guard let bar else {
               throw QueryDecodingError.missingRequiredColumn
@@ -235,20 +235,20 @@ extension SnapshotTests {
           var c4 = ""
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let c1 = StructuredQueries.TableColumn<QueryValue, Swift.Bool>("c1", keyPath: \QueryValue.c1, default: true)
-            public let c2 = StructuredQueries.TableColumn<QueryValue, Swift.Int>("c2", keyPath: \QueryValue.c2, default: 1)
-            public let c3 = StructuredQueries.TableColumn<QueryValue, Swift.Double>("c3", keyPath: \QueryValue.c3, default: 1.2)
-            public let c4 = StructuredQueries.TableColumn<QueryValue, Swift.String>("c4", keyPath: \QueryValue.c4, default: "")
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let c1 = StructuredQueriesCore.TableColumn<QueryValue, Swift.Bool>("c1", keyPath: \QueryValue.c1, default: true)
+            public let c2 = StructuredQueriesCore.TableColumn<QueryValue, Swift.Int>("c2", keyPath: \QueryValue.c2, default: 1)
+            public let c3 = StructuredQueriesCore.TableColumn<QueryValue, Swift.Double>("c3", keyPath: \QueryValue.c3, default: 1.2)
+            public let c4 = StructuredQueriesCore.TableColumn<QueryValue, Swift.String>("c4", keyPath: \QueryValue.c4, default: "")
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.c1, QueryValue.columns.c2, QueryValue.columns.c3, QueryValue.columns.c4]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.c1 = try decoder.decode(Swift.Bool.self) ?? true
             self.c2 = try decoder.decode(Swift.Int.self) ?? 1
             self.c3 = try decoder.decode(Swift.Double.self) ?? 1.2
@@ -274,17 +274,17 @@ extension SnapshotTests {
           var bar: Int
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Int>("Bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Int>("Bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(Int.self)
             guard let bar else {
               throw QueryDecodingError.missingRequiredColumn
@@ -355,17 +355,17 @@ extension SnapshotTests {
           var bar: Date
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Date.ISO8601Representation>("bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Date.ISO8601Representation>("bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(Date.ISO8601Representation.self)
             guard let bar else {
               throw QueryDecodingError.missingRequiredColumn
@@ -393,17 +393,17 @@ extension SnapshotTests {
           var baz: Int { 42 }
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(Int.self)
             guard let bar else {
               throw QueryDecodingError.missingRequiredColumn
@@ -431,17 +431,17 @@ extension SnapshotTests {
           static var baz: Int { 42 }
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(Int.self)
             guard let bar else {
               throw QueryDecodingError.missingRequiredColumn
@@ -487,17 +487,17 @@ extension SnapshotTests {
           var bar: Date
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Date.ISO8601Representation>("bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Date.ISO8601Representation>("bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(Date.ISO8601Representation.self)
             guard let bar else {
               throw QueryDecodingError.missingRequiredColumn
@@ -543,17 +543,17 @@ extension SnapshotTests {
           var bar: Date?
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Date.ISO8601Representation?>("bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Date.ISO8601Representation?>("bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.bar = try decoder.decode(Date.ISO8601Representation.self)
           }
         }
@@ -595,17 +595,17 @@ extension SnapshotTests {
           var bar: Optional<Date>
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Date.ISO8601Representation?>("bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Date.ISO8601Representation?>("bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.bar = try decoder.decode(Date.ISO8601Representation.self)
           }
         }
@@ -647,17 +647,17 @@ extension SnapshotTests {
           var bar = Date()
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, Date.ISO8601Representation>("bar", keyPath: \QueryValue.bar, default: Date())
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, Date.ISO8601Representation>("bar", keyPath: \QueryValue.bar, default: Date())
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.bar = try decoder.decode(Date.ISO8601Representation.self) ?? Date()
           }
         }
@@ -679,17 +679,17 @@ extension SnapshotTests {
           var `bar`: Int
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let `bar` = StructuredQueries.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.`bar`)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let `bar` = StructuredQueriesCore.TableColumn<QueryValue, Int>("bar", keyPath: \QueryValue.`bar`)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.`bar`]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let `bar` = try decoder.decode(Int.self)
             guard let `bar` else {
               throw QueryDecodingError.missingRequiredColumn
@@ -715,17 +715,17 @@ extension SnapshotTests {
           var bar: ID<Self>
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, ID<Foo>>("bar", keyPath: \QueryValue.bar)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, ID<Foo>>("bar", keyPath: \QueryValue.bar)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(ID<Foo>.self)
             guard let bar else {
               throw QueryDecodingError.missingRequiredColumn
@@ -751,17 +751,17 @@ extension SnapshotTests {
           var bar = ID<Self>()
         }
 
-        extension Foo: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo
-            public let bar = StructuredQueries.TableColumn<QueryValue, _>("bar", keyPath: \QueryValue.bar, default: ID<Foo>())
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let bar = StructuredQueriesCore.TableColumn<QueryValue, _>("bar", keyPath: \QueryValue.bar, default: ID<Foo>())
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.bar]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.bar = try decoder.decode() ?? ID<Foo>()
           }
         }
@@ -787,33 +787,33 @@ extension SnapshotTests {
           var referrerID: ID<Self, UUID>?
         }
 
-        extension User: StructuredQueries.Table, StructuredQueries.PrimaryKeyedTable {
-          public struct TableColumns: StructuredQueries.TableDefinition, StructuredQueries.PrimaryKeyedTableDefinition {
+        extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
             public typealias QueryValue = User
-            public let id = StructuredQueries.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>>("id", keyPath: \QueryValue.id)
-            public let referrerID = StructuredQueries.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>?>("referrerID", keyPath: \QueryValue.referrerID)
-            public var primaryKey: StructuredQueries.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>> {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>>("id", keyPath: \QueryValue.id)
+            public let referrerID = StructuredQueriesCore.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>?>("referrerID", keyPath: \QueryValue.referrerID)
+            public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>> {
               self.id
             }
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id, QueryValue.columns.referrerID]
             }
           }
-          public struct Draft: StructuredQueries.TableDraft {
+          public struct Draft: StructuredQueriesCore.TableDraft {
             public typealias PrimaryTable = User
             @Column(as: ID<User, UUID.BytesRepresentation>?.self, primaryKey: false) let id: ID<User, UUID>?
             @Column(as: ID<User, UUID.BytesRepresentation>?.self) var referrerID: ID<User, UUID>?
-            public struct TableColumns: StructuredQueries.TableDefinition {
+            public struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = User.Draft
-              public let id = StructuredQueries.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>?>("id", keyPath: \QueryValue.id)
-              public let referrerID = StructuredQueries.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>?>("referrerID", keyPath: \QueryValue.referrerID)
-              public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+              public let id = StructuredQueriesCore.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>?>("id", keyPath: \QueryValue.id)
+              public let referrerID = StructuredQueriesCore.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>?>("referrerID", keyPath: \QueryValue.referrerID)
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
                 [QueryValue.columns.id, QueryValue.columns.referrerID]
               }
             }
             public static let columns = TableColumns()
             public static let tableName = User.tableName
-            public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+            public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               self.id = try decoder.decode(ID<User, UUID.BytesRepresentation>.self)
               self.referrerID = try decoder.decode(ID<User, UUID.BytesRepresentation>.self)
             }
@@ -831,7 +831,7 @@ extension SnapshotTests {
           }
           public static let columns = TableColumns()
           public static let tableName = "users"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(ID<User, UUID.BytesRepresentation>.self)
             self.referrerID = try decoder.decode(ID<User, UUID.BytesRepresentation>.self)
             guard let id else {
@@ -860,17 +860,17 @@ extension SnapshotTests {
           var computed: Int
         }
 
-        extension SyncUp: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension SyncUp: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = SyncUp
-            public let name = StructuredQueries.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let name = StructuredQueriesCore.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.name]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "syncUps"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let name = try decoder.decode(String.self)
             guard let name else {
               throw QueryDecodingError.missingRequiredColumn
@@ -900,34 +900,34 @@ extension SnapshotTests {
           var computed: Int
         }
 
-        extension SyncUp: StructuredQueries.Table, StructuredQueries.PrimaryKeyedTable {
-          public struct TableColumns: StructuredQueries.TableDefinition, StructuredQueries.PrimaryKeyedTableDefinition {
+        extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
             public typealias QueryValue = SyncUp
-            public let id = StructuredQueries.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
-            public let name = StructuredQueries.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
-            public var primaryKey: StructuredQueries.TableColumn<QueryValue, Int> {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
+            public let name = StructuredQueriesCore.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
+            public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, Int> {
               self.id
             }
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id, QueryValue.columns.name]
             }
           }
-          public struct Draft: StructuredQueries.TableDraft {
+          public struct Draft: StructuredQueriesCore.TableDraft {
             public typealias PrimaryTable = SyncUp
             @Column(primaryKey: false)
             let id: Int?
             var name: String
-            public struct TableColumns: StructuredQueries.TableDefinition {
+            public struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = SyncUp.Draft
-              public let id = StructuredQueries.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
-              public let name = StructuredQueries.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
-              public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+              public let id = StructuredQueriesCore.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
+              public let name = StructuredQueriesCore.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
                 [QueryValue.columns.id, QueryValue.columns.name]
               }
             }
             public static let columns = TableColumns()
             public static let tableName = SyncUp.tableName
-            public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+            public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               self.id = try decoder.decode(Int.self)
               let name = try decoder.decode(String.self)
               guard let name else {
@@ -949,7 +949,7 @@ extension SnapshotTests {
           }
           public static let columns = TableColumns()
           public static let tableName = "syncUps"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(Int.self)
             let name = try decoder.decode(String.self)
             guard let id else {
@@ -998,34 +998,34 @@ extension SnapshotTests {
           var seconds: <#Type#> = 60 * 5
         }
 
-        extension SyncUp: StructuredQueries.Table, StructuredQueries.PrimaryKeyedTable {
-          public struct TableColumns: StructuredQueries.TableDefinition, StructuredQueries.PrimaryKeyedTableDefinition {
+        extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
             public typealias QueryValue = SyncUp
-            public let id = StructuredQueries.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
-            public let seconds = StructuredQueries.TableColumn<QueryValue, <#Type#>>("seconds", keyPath: \QueryValue.seconds, default: 60 * 5)
-            public var primaryKey: StructuredQueries.TableColumn<QueryValue, Int> {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
+            public let seconds = StructuredQueriesCore.TableColumn<QueryValue, <#Type#>>("seconds", keyPath: \QueryValue.seconds, default: 60 * 5)
+            public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, Int> {
               self.id
             }
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id, QueryValue.columns.seconds]
             }
           }
-          public struct Draft: StructuredQueries.TableDraft {
+          public struct Draft: StructuredQueriesCore.TableDraft {
             public typealias PrimaryTable = SyncUp
             @Column(primaryKey: false)
             let id: Int?
             var seconds: <#Type#> = 60 * 5
-            public struct TableColumns: StructuredQueries.TableDefinition {
+            public struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = SyncUp.Draft
-              public let id = StructuredQueries.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
-              public let seconds = StructuredQueries.TableColumn<QueryValue, <#Type#>>("seconds", keyPath: \QueryValue.seconds, default: 60 * 5)
-              public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+              public let id = StructuredQueriesCore.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
+              public let seconds = StructuredQueriesCore.TableColumn<QueryValue, <#Type#>>("seconds", keyPath: \QueryValue.seconds, default: 60 * 5)
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
                 [QueryValue.columns.id, QueryValue.columns.seconds]
               }
             }
             public static let columns = TableColumns()
             public static let tableName = SyncUp.tableName
-            public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+            public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               self.id = try decoder.decode(Int.self)
               self.seconds = try decoder.decode(<#Type#>.self) ?? 60 * 5
             }
@@ -1043,7 +1043,7 @@ extension SnapshotTests {
           }
           public static let columns = TableColumns()
           public static let tableName = "syncUps"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(Int.self)
             self.seconds = try decoder.decode(<#Type#>.self) ?? 60 * 5
             guard let id else {
@@ -1075,37 +1075,37 @@ extension SnapshotTests {
           var name = ""
         }
 
-        extension RemindersList: StructuredQueries.Table, StructuredQueries.PrimaryKeyedTable {
-          public struct TableColumns: StructuredQueries.TableDefinition, StructuredQueries.PrimaryKeyedTableDefinition {
+        extension RemindersList: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
             public typealias QueryValue = RemindersList
-            public let id = StructuredQueries.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
-            public let color = StructuredQueries.TableColumn<QueryValue, Color.HexRepresentation>("color", keyPath: \QueryValue.color, default: Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255))
-            public let name = StructuredQueries.TableColumn<QueryValue, Swift.String>("name", keyPath: \QueryValue.name, default: "")
-            public var primaryKey: StructuredQueries.TableColumn<QueryValue, Int> {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
+            public let color = StructuredQueriesCore.TableColumn<QueryValue, Color.HexRepresentation>("color", keyPath: \QueryValue.color, default: Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255))
+            public let name = StructuredQueriesCore.TableColumn<QueryValue, Swift.String>("name", keyPath: \QueryValue.name, default: "")
+            public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, Int> {
               self.id
             }
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id, QueryValue.columns.color, QueryValue.columns.name]
             }
           }
-          public struct Draft: StructuredQueries.TableDraft {
+          public struct Draft: StructuredQueriesCore.TableDraft {
             public typealias PrimaryTable = RemindersList
             @Column(primaryKey: false)
             var id: Int?
             @Column(as: Color.HexRepresentation.self) var color = Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255)
             var name = ""
-            public struct TableColumns: StructuredQueries.TableDefinition {
+            public struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = RemindersList.Draft
-              public let id = StructuredQueries.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
-              public let color = StructuredQueries.TableColumn<QueryValue, Color.HexRepresentation>("color", keyPath: \QueryValue.color, default: Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255))
-              public let name = StructuredQueries.TableColumn<QueryValue, Swift.String>("name", keyPath: \QueryValue.name, default: "")
-              public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+              public let id = StructuredQueriesCore.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
+              public let color = StructuredQueriesCore.TableColumn<QueryValue, Color.HexRepresentation>("color", keyPath: \QueryValue.color, default: Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255))
+              public let name = StructuredQueriesCore.TableColumn<QueryValue, Swift.String>("name", keyPath: \QueryValue.name, default: "")
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
                 [QueryValue.columns.id, QueryValue.columns.color, QueryValue.columns.name]
               }
             }
             public static let columns = TableColumns()
             public static let tableName = RemindersList.tableName
-            public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+            public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               self.id = try decoder.decode(Int.self)
               self.color = try decoder.decode(Color.HexRepresentation.self) ?? Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255)
               self.name = try decoder.decode(Swift.String.self) ?? ""
@@ -1127,7 +1127,7 @@ extension SnapshotTests {
           }
           public static let columns = TableColumns()
           public static let tableName = "remindersLists"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(Int.self)
             self.color = try decoder.decode(Color.HexRepresentation.self) ?? Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255)
             self.name = try decoder.decode(Swift.String.self) ?? ""
@@ -1178,17 +1178,17 @@ extension SnapshotTests {
         }
       }
 
-      extension Foo: StructuredQueries.Table {
-        public struct TableColumns: StructuredQueries.TableDefinition {
+      extension Foo: StructuredQueriesCore.Table {
+        public struct TableColumns: StructuredQueriesCore.TableDefinition {
           public typealias QueryValue = Foo
-          public let name = StructuredQueries.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
-          public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+          public let name = StructuredQueriesCore.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
+          public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
             [QueryValue.columns.name]
           }
         }
         public static let columns = TableColumns()
         public static let tableName = "foos"
-        public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+        public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
           let name = try decoder.decode(String.self)
           guard let name else {
             throw QueryDecodingError.missingRequiredColumn
@@ -1216,31 +1216,31 @@ extension SnapshotTests {
           let id: Int
         }
 
-        extension Foo: StructuredQueries.Table, StructuredQueries.PrimaryKeyedTable {
-          public struct TableColumns: StructuredQueries.TableDefinition, StructuredQueries.PrimaryKeyedTableDefinition {
+        extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
             public typealias QueryValue = Foo
-            public let id = StructuredQueries.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
-            public var primaryKey: StructuredQueries.TableColumn<QueryValue, Int> {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
+            public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, Int> {
               self.id
             }
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id]
             }
           }
-          public struct Draft: StructuredQueries.TableDraft {
+          public struct Draft: StructuredQueriesCore.TableDraft {
             public typealias PrimaryTable = Foo
             @Column(primaryKey: false)
             let id: Int?
-            public struct TableColumns: StructuredQueries.TableDefinition {
+            public struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = Foo.Draft
-              public let id = StructuredQueries.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
-              public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+              public let id = StructuredQueriesCore.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
                 [QueryValue.columns.id]
               }
             }
             public static let columns = TableColumns()
             public static let tableName = Foo.tableName
-            public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+            public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               self.id = try decoder.decode(Int.self)
             }
             public init(_ other: Foo) {
@@ -1254,7 +1254,7 @@ extension SnapshotTests {
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(Int.self)
             guard let id else {
               throw QueryDecodingError.missingRequiredColumn
@@ -1316,17 +1316,17 @@ extension SnapshotTests {
           }
         }
 
-        extension Foo.Draft: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Foo.Draft: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Foo.Draft
-            public let id = StructuredQueries.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = Foo.tableName
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(Int.self)
             guard let id else {
               throw QueryDecodingError.missingRequiredColumn
@@ -1365,34 +1365,34 @@ extension SnapshotTests {
           }
         }
 
-        extension Foo: StructuredQueries.Table, StructuredQueries.PrimaryKeyedTable {
-          public struct TableColumns: StructuredQueries.TableDefinition, StructuredQueries.PrimaryKeyedTableDefinition {
+        extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
             public typealias QueryValue = Foo
-            public let id = StructuredQueries.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
-            public let name = StructuredQueries.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
-            public var primaryKey: StructuredQueries.TableColumn<QueryValue, Int> {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
+            public let name = StructuredQueriesCore.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
+            public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, Int> {
               self.id
             }
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id, QueryValue.columns.name]
             }
           }
-          public struct Draft: StructuredQueries.TableDraft {
+          public struct Draft: StructuredQueriesCore.TableDraft {
             public typealias PrimaryTable = Foo
             @Column(primaryKey: false)
             var id: Int?
             var name: String
-            public struct TableColumns: StructuredQueries.TableDefinition {
+            public struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = Foo.Draft
-              public let id = StructuredQueries.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
-              public let name = StructuredQueries.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
-              public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+              public let id = StructuredQueriesCore.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
+              public let name = StructuredQueriesCore.TableColumn<QueryValue, String>("name", keyPath: \QueryValue.name)
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
                 [QueryValue.columns.id, QueryValue.columns.name]
               }
             }
             public static let columns = TableColumns()
             public static let tableName = Foo.tableName
-            public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+            public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               self.id = try decoder.decode(Int.self)
               let name = try decoder.decode(String.self)
               guard let name else {
@@ -1414,7 +1414,7 @@ extension SnapshotTests {
           }
           public static let columns = TableColumns()
           public static let tableName = "foos"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(Int.self)
             let name = try decoder.decode(String.self)
             guard let id else {
@@ -1452,40 +1452,40 @@ extension SnapshotTests {
           var priority: Priority?
         }
 
-        extension Reminder: StructuredQueries.Table, StructuredQueries.PrimaryKeyedTable {
-          public struct TableColumns: StructuredQueries.TableDefinition, StructuredQueries.PrimaryKeyedTableDefinition {
+        extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
             public typealias QueryValue = Reminder
-            public let id = StructuredQueries.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
-            public let title = StructuredQueries.TableColumn<QueryValue, Swift.String>("title", keyPath: \QueryValue.title, default: "")
-            public let date = StructuredQueries.TableColumn<QueryValue, Date.UnixTimeRepresentation?>("date", keyPath: \QueryValue.date)
-            public let priority = StructuredQueries.TableColumn<QueryValue, Priority?>("priority", keyPath: \QueryValue.priority)
-            public var primaryKey: StructuredQueries.TableColumn<QueryValue, Int> {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
+            public let title = StructuredQueriesCore.TableColumn<QueryValue, Swift.String>("title", keyPath: \QueryValue.title, default: "")
+            public let date = StructuredQueriesCore.TableColumn<QueryValue, Date.UnixTimeRepresentation?>("date", keyPath: \QueryValue.date)
+            public let priority = StructuredQueriesCore.TableColumn<QueryValue, Priority?>("priority", keyPath: \QueryValue.priority)
+            public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, Int> {
               self.id
             }
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id, QueryValue.columns.title, QueryValue.columns.date, QueryValue.columns.priority]
             }
           }
-          public struct Draft: StructuredQueries.TableDraft {
+          public struct Draft: StructuredQueriesCore.TableDraft {
             public typealias PrimaryTable = Reminder
             @Column(primaryKey: false)
             let id: Int?
             var title = ""
             @Column(as: Date.UnixTimeRepresentation?.self) var date: Date?
             var priority: Priority?
-            public struct TableColumns: StructuredQueries.TableDefinition {
+            public struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = Reminder.Draft
-              public let id = StructuredQueries.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
-              public let title = StructuredQueries.TableColumn<QueryValue, Swift.String>("title", keyPath: \QueryValue.title, default: "")
-              public let date = StructuredQueries.TableColumn<QueryValue, Date.UnixTimeRepresentation?>("date", keyPath: \QueryValue.date)
-              public let priority = StructuredQueries.TableColumn<QueryValue, Priority?>("priority", keyPath: \QueryValue.priority)
-              public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+              public let id = StructuredQueriesCore.TableColumn<QueryValue, Int?>("id", keyPath: \QueryValue.id)
+              public let title = StructuredQueriesCore.TableColumn<QueryValue, Swift.String>("title", keyPath: \QueryValue.title, default: "")
+              public let date = StructuredQueriesCore.TableColumn<QueryValue, Date.UnixTimeRepresentation?>("date", keyPath: \QueryValue.date)
+              public let priority = StructuredQueriesCore.TableColumn<QueryValue, Priority?>("priority", keyPath: \QueryValue.priority)
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
                 [QueryValue.columns.id, QueryValue.columns.title, QueryValue.columns.date, QueryValue.columns.priority]
               }
             }
             public static let columns = TableColumns()
             public static let tableName = Reminder.tableName
-            public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+            public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               self.id = try decoder.decode(Int.self)
               self.title = try decoder.decode(Swift.String.self) ?? ""
               self.date = try decoder.decode(Date.UnixTimeRepresentation.self)
@@ -1511,7 +1511,7 @@ extension SnapshotTests {
           }
           public static let columns = TableColumns()
           public static let tableName = "reminders"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(Int.self)
             self.title = try decoder.decode(Swift.String.self) ?? ""
             self.date = try decoder.decode(Date.UnixTimeRepresentation.self)
@@ -1541,30 +1541,30 @@ extension SnapshotTests {
           let id: UUID
         }
 
-        extension Reminder: StructuredQueries.Table, StructuredQueries.PrimaryKeyedTable {
-          public struct TableColumns: StructuredQueries.TableDefinition, StructuredQueries.PrimaryKeyedTableDefinition {
+        extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
             public typealias QueryValue = Reminder
-            public let id = StructuredQueries.TableColumn<QueryValue, UUID.BytesRepresentation>("id", keyPath: \QueryValue.id)
-            public var primaryKey: StructuredQueries.TableColumn<QueryValue, UUID.BytesRepresentation> {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, UUID.BytesRepresentation>("id", keyPath: \QueryValue.id)
+            public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, UUID.BytesRepresentation> {
               self.id
             }
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id]
             }
           }
-          public struct Draft: StructuredQueries.TableDraft {
+          public struct Draft: StructuredQueriesCore.TableDraft {
             public typealias PrimaryTable = Reminder
             @Column(as: UUID.BytesRepresentation?.self, primaryKey: false) let id: UUID?
-            public struct TableColumns: StructuredQueries.TableDefinition {
+            public struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = Reminder.Draft
-              public let id = StructuredQueries.TableColumn<QueryValue, UUID.BytesRepresentation?>("id", keyPath: \QueryValue.id)
-              public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+              public let id = StructuredQueriesCore.TableColumn<QueryValue, UUID.BytesRepresentation?>("id", keyPath: \QueryValue.id)
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
                 [QueryValue.columns.id]
               }
             }
             public static let columns = TableColumns()
             public static let tableName = Reminder.tableName
-            public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+            public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               self.id = try decoder.decode(UUID.BytesRepresentation.self)
             }
             public init(_ other: Reminder) {
@@ -1578,7 +1578,7 @@ extension SnapshotTests {
           }
           public static let columns = TableColumns()
           public static let tableName = "reminders"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(UUID.BytesRepresentation.self)
             guard let id else {
               throw QueryDecodingError.missingRequiredColumn
@@ -1605,17 +1605,17 @@ extension SnapshotTests {
           let id: Int
         }
 
-        extension Reminder: StructuredQueries.Table {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension Reminder: StructuredQueriesCore.Table {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = Reminder
-            public let id = StructuredQueries.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let id = StructuredQueriesCore.TableColumn<QueryValue, Int>("id", keyPath: \QueryValue.id)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.id]
             }
           }
           public static let columns = TableColumns()
           public static let tableName = "reminders"
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(Int.self)
             guard let id else {
               throw QueryDecodingError.missingRequiredColumn

--- a/Tests/StructuredQueriesMacrosTests/TableSelectionMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableSelectionMacroTests.swift
@@ -21,12 +21,12 @@ extension SnapshotTests {
           let remindersCount: Int
         }
 
-        extension ReminderListWithCount: StructuredQueries.Table, StructuredQueries.PartialSelectStatement {
-          public struct TableColumns: StructuredQueries.TableDefinition {
+        extension ReminderListWithCount: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
+          public struct TableColumns: StructuredQueriesCore.TableDefinition {
             public typealias QueryValue = ReminderListWithCount
-            public let reminderList = StructuredQueries.TableColumn<QueryValue, ReminderList>("reminderList", keyPath: \QueryValue.reminderList)
-            public let remindersCount = StructuredQueries.TableColumn<QueryValue, Int>("remindersCount", keyPath: \QueryValue.remindersCount)
-            public static var allColumns: [any StructuredQueries.TableColumnExpression] {
+            public let reminderList = StructuredQueriesCore.TableColumn<QueryValue, ReminderList>("reminderList", keyPath: \QueryValue.reminderList)
+            public let remindersCount = StructuredQueriesCore.TableColumn<QueryValue, Int>("remindersCount", keyPath: \QueryValue.remindersCount)
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               [QueryValue.columns.reminderList, QueryValue.columns.remindersCount]
             }
           }
@@ -36,20 +36,20 @@ extension SnapshotTests {
           public static let tableName = "reminderListWithCounts"
         }
 
-        extension ReminderListWithCount: StructuredQueries.QueryRepresentable {
-          public struct Columns: StructuredQueries.QueryExpression {
+        extension ReminderListWithCount: StructuredQueriesCore.QueryRepresentable {
+          public struct Columns: StructuredQueriesCore.QueryExpression {
             public typealias QueryValue = ReminderListWithCount
-            public let queryFragment: StructuredQueries.QueryFragment
+            public let queryFragment: StructuredQueriesCore.QueryFragment
             public init(
-              reminderList: some StructuredQueries.QueryExpression<ReminderList>,
-              remindersCount: some StructuredQueries.QueryExpression<Int>
+              reminderList: some StructuredQueriesCore.QueryExpression<ReminderList>,
+              remindersCount: some StructuredQueriesCore.QueryExpression<Int>
             ) {
               self.queryFragment = """
               \(reminderList.queryFragment) AS "reminderList", \(remindersCount.queryFragment) AS "remindersCount"
               """
             }
           }
-          public init(decoder: inout some StructuredQueries.QueryDecoder) throws {
+          public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let reminderList = try decoder.decode(ReminderList.self)
             let remindersCount = try decoder.decode(Int.self)
             guard let reminderList else {

--- a/Tests/StructuredQueriesTests/SQLMacroTests.swift
+++ b/Tests/StructuredQueriesTests/SQLMacroTests.swift
@@ -132,7 +132,7 @@ extension SnapshotTests {
       struct ReminderResult: QueryRepresentable {
         let title: String
         let isCompleted: Bool
-        init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+        init(decoder: inout some QueryDecoder) throws {
           guard let title = try decoder.decode(String.self)
           else { throw QueryDecodingError.missingRequiredColumn }
           guard let isCompleted = try decoder.decode(Bool.self)


### PR DESCRIPTION
This is the more correct thing to do, and has the added benefit of being able to inline the macro for copy-paste for targets that do not want to use the macro.