### PR TITLE
Add support for explicit schema names

### DIFF
--- a/Sources/StructuredQueries/Macros.swift
+++ b/Sources/StructuredQueries/Macros.swift
@@ -16,12 +16,16 @@ import StructuredQueriesCore
   named(init(_:)),
   named(init(decoder:)),
   named(QueryValue),
+  named(schemaName),
   named(tableName)
 )
 @attached(
   memberAttribute
 )
-public macro Table(_ name: String? = nil) =
+public macro Table(
+  _ name: String? = nil,
+  schema schemaName: String? = nil
+) =
   #externalMacro(
     module: "StructuredQueriesMacros",
     type: "TableMacro"

--- a/Sources/StructuredQueriesCore/QueryFragment.swift
+++ b/Sources/StructuredQueriesCore/QueryFragment.swift
@@ -262,6 +262,10 @@ extension QueryFragment: ExpressibleByStringInterpolation {
     ///
     /// - Parameter table: A table.
     public mutating func appendInterpolation<T: Table>(_ table: T.Type) {
+      if let schemaName = table.schemaName {
+        appendInterpolation(quote: schemaName)
+        appendLiteral(".")
+      }
       appendInterpolation(quote: table.tableAlias ?? table.tableName)
     }
 

--- a/Sources/StructuredQueriesCore/Statements/CommonTableExpression.swift
+++ b/Sources/StructuredQueriesCore/Statements/CommonTableExpression.swift
@@ -39,10 +39,10 @@ public struct With<QueryValue>: Statement {
 
 public struct CommonTableExpressionClause: QueryExpression {
   public typealias QueryValue = ()
-  let tableName: String
+  let tableName: QueryFragment
   let select: QueryFragment
   public var queryFragment: QueryFragment {
-    "\(quote: tableName) AS (\(.newline)\(select.indented())\(.newline))"
+    "\(tableName) AS (\(.newline)\(select.indented())\(.newline))"
   }
 }
 
@@ -55,7 +55,7 @@ public enum CommonTableExpressionBuilder {
   public static func buildExpression<CTETable: Table>(
     _ expression: some PartialSelectStatement<CTETable>
   ) -> CommonTableExpressionClause {
-    CommonTableExpressionClause(tableName: CTETable.tableName, select: expression.query)
+    CommonTableExpressionClause(tableName: "\(CTETable.self)", select: expression.query)
   }
 
   public static func buildBlock(

--- a/Sources/StructuredQueriesCore/Statements/Delete.swift
+++ b/Sources/StructuredQueriesCore/Statements/Delete.swift
@@ -135,7 +135,11 @@ extension Delete: Statement {
   public typealias QueryValue = Returning
 
   public var query: QueryFragment {
-    var query: QueryFragment = "DELETE FROM \(quote: From.tableName)"
+    var query: QueryFragment = "DELETE FROM "
+    if let schemaName = From.schemaName {
+      query.append("\(quote: schemaName).")
+    }
+    query.append("\(quote: From.tableName)")
     if let tableAlias = From.tableAlias {
       query.append(" AS \(quote: tableAlias)")
     }

--- a/Sources/StructuredQueriesCore/Statements/Insert.swift
+++ b/Sources/StructuredQueriesCore/Statements/Insert.swift
@@ -403,7 +403,11 @@ extension Insert: Statement {
     if let conflictResolution {
       query.append(" OR \(conflictResolution)")
     }
-    query.append(" INTO \(quote: Into.tableName)")
+    query.append(" INTO ")
+    if let schemaName = Into.schemaName {
+      query.append("\(quote: schemaName).")
+    }
+    query.append("\(quote: Into.tableName)")
     if let tableAlias = Into.tableAlias {
       query.append(" AS \(quote: tableAlias)")
     }

--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -1410,7 +1410,11 @@ extension Select: SelectStatement {
       query.append(" DISTINCT")
     }
     query.append(" \(columns.joined(separator: ", "))")
-    query.append("\(.newlineOrSpace)FROM \(quote: From.tableName)")
+    query.append("\(.newlineOrSpace)FROM ")
+    if let schemaName = From.schemaName {
+      query.append("\(quote: schemaName).")
+    }
+    query.append("\(quote: From.tableName)")
     if let tableAlias = From.tableAlias {
       query.append(" AS \(quote: tableAlias)")
     }

--- a/Sources/StructuredQueriesCore/Statements/Update.swift
+++ b/Sources/StructuredQueriesCore/Statements/Update.swift
@@ -196,11 +196,14 @@ extension Update: Statement {
     guard !updates.isEmpty
     else { return "" }
 
-    var query: QueryFragment = "UPDATE"
+    var query: QueryFragment = "UPDATE "
     if let conflictResolution {
-      query.append(" OR \(conflictResolution)")
+      query.append("OR \(conflictResolution) ")
     }
-    query.append(" \(quote: From.tableName)")
+    if let schemaName = From.schemaName {
+      query.append("\(quote: schemaName).")
+    }
+    query.append("\(quote: From.tableName)")
     if let tableAlias = From.tableAlias {
       query.append(" AS \(quote: tableAlias)")
     }

--- a/Sources/StructuredQueriesCore/Table.swift
+++ b/Sources/StructuredQueriesCore/Table.swift
@@ -21,6 +21,9 @@ public protocol Table: QueryRepresentable where TableColumns.QueryValue == Self 
   /// This property should always return `nil` unless called on a ``TableAlias``.
   static var tableAlias: String? { get }
 
+  /// The table schema's name.
+  static var schemaName: String? { get }
+
   /// A select statement for this table.
   ///
   /// The default implementation of this property returns a fully unscoped query for the table
@@ -87,6 +90,10 @@ extension Table {
   }
 
   public static var tableAlias: String? {
+    nil
+  }
+
+  public static var schemaName: String? {
     nil
   }
 

--- a/Sources/StructuredQueriesTestSupport/AssertQuery.swift
+++ b/Sources/StructuredQueriesTestSupport/AssertQuery.swift
@@ -97,6 +97,22 @@ public func assertQuery<each V: QueryRepresentable, S: Statement<(repeat each V)
         line: line,
         column: column
       )
+    } else {
+      assertInlineSnapshot(
+        of: table,
+        as: .lines,
+        message: "Results did not match",
+        syntaxDescriptor: InlineSnapshotSyntaxDescriptor(
+          trailingClosureLabel: "results",
+          trailingClosureOffset: snapshotTrailingClosureOffset + 1
+        ),
+        matches: nil,
+        fileID: fileID,
+        file: filePath,
+        function: function,
+        line: line,
+        column: column
+      )
     }
   } catch {
     assertInlineSnapshot(

--- a/Sources/StructuredQueriesTestSupport/AssertQuery.swift
+++ b/Sources/StructuredQueriesTestSupport/AssertQuery.swift
@@ -97,22 +97,6 @@ public func assertQuery<each V: QueryRepresentable, S: Statement<(repeat each V)
         line: line,
         column: column
       )
-    } else {
-      assertInlineSnapshot(
-        of: table,
-        as: .lines,
-        message: "Results did not match",
-        syntaxDescriptor: InlineSnapshotSyntaxDescriptor(
-          trailingClosureLabel: "results",
-          trailingClosureOffset: snapshotTrailingClosureOffset + 1
-        ),
-        matches: nil,
-        fileID: fileID,
-        file: filePath,
-        function: function,
-        line: line,
-        column: column
-      )
     }
   } catch {
     assertInlineSnapshot(

--- a/Tests/StructuredQueriesTests/SchemaTests.swift
+++ b/Tests/StructuredQueriesTests/SchemaTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import InlineSnapshotTesting
+import StructuredQueries
+import Testing
+
+extension SnapshotTests {
+  @Suite struct SchemaNameTests {
+    @Test func select() {
+      assertQuery(Reminder.limit(1)) {
+        """
+        SELECT "main"."reminders"."id", "main"."reminders"."remindersListID"
+        FROM "main"."reminders"
+        LIMIT 1
+        """
+      } results: {
+        """
+        ┌─────────────────────────────────────────┐
+        │ SnapshotTests.SchemaNameTests.Reminder( │
+        │   id: 1,                                │
+        │   remindersListID: 1                    │
+        │ )                                       │
+        └─────────────────────────────────────────┘
+        """
+      }
+    }
+
+    @Test func insert() {
+      assertQuery(Reminder.insert(Reminder.Draft(remindersListID: 1))) {
+        """
+        INSERT INTO "main"."reminders"
+        ("id", "remindersListID")
+        VALUES
+        (NULL, 1)
+        """
+      }
+    }
+
+    @Test func update() {
+      assertQuery(Reminder.where { $0.remindersListID.eq(1) }.update { $0.remindersListID = 2 }) {
+        """
+        UPDATE "main"."reminders"
+        SET "remindersListID" = 2
+        WHERE ("main"."reminders"."remindersListID" = 1)
+        """
+      }
+    }
+
+    @Test func delete() {
+      assertQuery(Reminder.where { $0.remindersListID.eq(1) }.delete()) {
+        """
+        DELETE FROM "main"."reminders"
+        WHERE ("main"."reminders"."remindersListID" = 1)
+        """
+      }
+    }
+
+    @Table("reminders", schema: "main")
+    fileprivate struct Reminder {
+      let id: Int
+      let remindersListID: Int
+    }
+  }
+}


### PR DESCRIPTION
This is useful when an app connects to multiple schemas that have overlapping table names.