### PR TITLE
Don't remove current offset when chaining limits

### DIFF
--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/SelectStatements.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/SelectStatements.md
@@ -721,7 +721,8 @@ The `limit(_:offset:)` function is used to change a query's `LIMIT` and `OFFSET`
   }
 }
 
-Multiple chained calls to `limit` will override the limit and offset to the last call:
+Multiple chained calls to `limit` will override the limit and offset to the last call, using the
+existing offset if none is provided:
 
 @Row {
   @Column {
@@ -744,6 +745,22 @@ Multiple chained calls to `limit` will override the limit and offset to the last
     ```swift
     Reminder
       .limit(10)
+      .limit(20, offset: 20)
+    ```
+  }
+  @Column {
+    ```sql
+    SELECT … FROM "reminders"
+    LIMIT 20 OFFSET 20
+    ```
+  }
+}
+
+@Row {
+  @Column {
+    ```swift
+    Reminder
+      .limit(10, offset: 10)
       .limit(20, offset: 20)
     ```
   }

--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -1282,8 +1282,8 @@ extension Select {
   where Joins == (repeat each J) {
     var select = self
     select.limit = _LimitClause(
-      maxLength: maxLength(From.columns, repeat (each J).columns),
-      offset: offset?(From.columns, repeat (each J).columns)
+      maxLength: maxLength(From.columns, repeat (each J).columns).queryFragment,
+      offset: offset?(From.columns, repeat (each J).columns).queryFragment ?? select.limit?.offset
     )
     return select
   }
@@ -1297,7 +1297,10 @@ extension Select {
   public func limit<each J: Table>(_ maxLength: Int, offset: Int? = nil) -> Self
   where Joins == (repeat each J) {
     var select = self
-    select.limit = _LimitClause(maxLength: maxLength, offset: offset)
+    select.limit = _LimitClause(
+      maxLength: maxLength.queryFragment,
+      offset: offset?.queryFragment ?? select.limit?.offset
+    )
     return select
   }
 
@@ -1487,14 +1490,6 @@ public struct _LimitClause: QueryExpression {
 
   let maxLength: QueryFragment
   let offset: QueryFragment?
-
-  init(
-    maxLength: some QueryExpression,
-    offset: (some QueryExpression)? = Int?.none
-  ) {
-    self.maxLength = maxLength.queryFragment
-    self.offset = offset?.queryFragment
-  }
 
   public var queryFragment: QueryFragment {
     var query: QueryFragment = "LIMIT \(maxLength)"


### PR DESCRIPTION
Right now a `q.limit(1)` will strip the existing offset when it probably should't.

There are some wider, unknown implications with how the `LIMIT`/`OFFSET` clauses combine at the moment, and it'd be nice to codify in the future, but for now this at least fixes a potential bug.