### PR TITLE
_CodableJSONRepresentation Date Decoding

### DIFF
--- a/Sources/StructuredQueriesCore/QueryRepresentable/Codable+JSON.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/Codable+JSON.swift
@@ -64,6 +64,10 @@ private let jsonDecoder: JSONDecoder = {
 
 private let jsonEncoder: JSONEncoder = {
   var encoder = JSONEncoder()
+  encoder.dateEncodingStrategy = .custom { date, encoder in
+    var container = encoder.singleValueContainer()
+    try container.encode(date.iso8601String)
+  }
   #if DEBUG
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
   #endif


### PR DESCRIPTION
The date encoding / decoding strategy for `_CodableJSONRepresentation` do not match, so if you encode a value with a date to the database, you will not be able to to pull it later.