### PR TITLE
Add another `Select.select` overload

### DIFF
--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -444,6 +444,18 @@ extension Select {
     _select(selection)
   }
 
+  /// Creates a new select statement from this one by selecting the given result column.
+  ///
+  /// - Parameter selection: A closure that selects a result column from this select's tables.
+  /// - Returns: A new select statement that selects the given column.
+  @_disfavoredOverload
+  public func select<C: QueryExpression, each J: Table>(
+    _ selection: (From.TableColumns, repeat (each J).TableColumns) -> C
+  ) -> Select<C.QueryValue, From, (repeat each J)>
+  where Columns == (), C.QueryValue: QueryRepresentable, Joins == (repeat each J) {
+    _select(selection)
+  }
+
   /// Creates a new select statement from this one by appending the given result column to its
   /// selection.
   ///

--- a/Tests/StructuredQueriesTests/CompileTimeTests.swift
+++ b/Tests/StructuredQueriesTests/CompileTimeTests.swift
@@ -1,0 +1,21 @@
+import StructuredQueries
+
+// NB: This is a compile-time test for a 'select' overload.
+@Selection
+private struct ReminderRow {
+  let reminder: Reminder
+  let isPastDue: Bool
+  @Column(as: [String].JSONRepresentation.self)
+  let tags: [String]
+}
+private var remindersQuery: some Statement<ReminderRow> {
+  Reminder
+    .limit(1)
+    .select {
+      ReminderRow.Columns(
+        reminder: $0,
+        isPastDue: true,
+        tags: #sql("[]")
+      )
+    }
+}


### PR DESCRIPTION
We need to maintain overloads that overparenthesize the arguments passed to the `select` method to work around parameter pack bugs in Swift, but were missing one.