### PR TITLE
Fix `Table.count(filter:)`, etc.

### DIFF
--- a/Sources/StructuredQueriesCore/SQLite/JSONFunctions.swift
+++ b/Sources/StructuredQueriesCore/SQLite/JSONFunctions.swift
@@ -37,7 +37,12 @@ extension QueryExpression where QueryValue: Codable & QueryBindable & Sendable {
     filter: (some QueryExpression<Bool>)? = Bool?.none
   ) -> some QueryExpression<[QueryValue].JSONRepresentation> {
     AggregateFunction(
-      "json_group_array", isDistinct: isDistinct, self, order: order, filter: filter)
+      "json_group_array",
+      isDistinct: isDistinct,
+      [queryFragment],
+      order: order?.queryFragment,
+      filter: filter?.queryFragment
+    )
   }
 }
 
@@ -98,7 +103,12 @@ extension PrimaryKeyedTableDefinition where QueryValue: Codable & Sendable {
     filter: (some QueryExpression<Bool>)? = Bool?.none
   ) -> some QueryExpression<[QueryValue].JSONRepresentation> {
     AggregateFunction(
-      "json_group_array", isDistinct: isDistinct, jsonObject, order: order, filter: filter)
+      "json_group_array",
+      isDistinct: isDistinct,
+      [jsonObject.queryFragment],
+      order: order?.queryFragment,
+      filter: filter?.queryFragment
+    )
   }
 
   private var jsonObject: some QueryExpression<QueryValue> {

--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -295,7 +295,7 @@ extension Table {
   /// - Parameter filter: A `FILTER` clause to apply to the aggregation.
   /// - Returns: A select statement that selects `count(*)`.
   public static func count(
-    filter: (some QueryExpression<Bool>)? = Bool?.none
+    filter: ((TableColumns) -> any QueryExpression<Bool>)? = nil
   ) -> Select<Int, Self, ()> {
     Where().count(filter: filter)
   }
@@ -1321,10 +1321,11 @@ extension Select {
   /// - Parameter filter: A `FILTER` clause to apply to the aggregation.
   /// - Returns: A new select statement that selects `count(*)`.
   public func count<each J: Table>(
-    filter: (some QueryExpression<Bool>)? = Bool?.none
+    filter: ((From.TableColumns, repeat (each J).TableColumns) -> any QueryExpression<Bool>)? = nil
   ) -> Select<Int, From, (repeat each J)>
   where Columns == (), Joins == (repeat each J) {
-    select { _ in .count(filter: filter) }
+    let filter = filter?(From.columns, repeat (each J).columns)
+    return select { _ in .count(filter: filter) }
   }
 
   /// Creates a new select statement from this one by appending `count(*)` to its selection.
@@ -1332,12 +1333,13 @@ extension Select {
   /// - Parameter filter: A `FILTER` clause to apply to the aggregation.
   /// - Returns: A new select statement that selects `count(*)`.
   public func count<each C: QueryRepresentable, each J: Table>(
-    filter: (some QueryExpression<Bool>)? = Bool?.none
+    filter: ((From.TableColumns, repeat (each J).TableColumns) -> any QueryExpression<Bool>)? = nil
   ) -> Select<
     (repeat each C, Int), From, (repeat each J)
   >
   where Columns == (repeat each C), Joins == (repeat each J) {
-    select { _ in .count(filter: filter) }
+    let filter = filter?(From.columns, repeat (each J).columns)
+    return select { _ in .count(filter: filter) }
   }
 
   /// Creates a new select statement from this one by transforming its selected columns to a new

--- a/Sources/StructuredQueriesCore/Statements/Where.swift
+++ b/Sources/StructuredQueriesCore/Statements/Where.swift
@@ -462,7 +462,7 @@ extension Where: SelectStatement {
   /// - Parameter filter: A `FILTER` clause to apply to the aggregation.
   /// - Returns: A select statement that selects `count(*)`.
   public func count(
-    filter: (some QueryExpression<Bool>)? = Bool?.none
+    filter: ((From.TableColumns) -> any QueryExpression<Bool>)? = nil
   ) -> Select<Int, From, ()> {
     asSelect().count(filter: filter)
   }

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -857,6 +857,21 @@ extension SnapshotTests {
       }
     }
 
+    @Test func countFilter() {
+      assertQuery(Reminder.count { !$0.isCompleted }) {
+        """
+        SELECT count(*) FILTER (WHERE NOT ("reminders"."isCompleted"))
+        FROM "reminders"
+        """
+      } results: {
+        """
+        ┌───┐
+        │ 7 │
+        └───┘
+        """
+      }
+    }
+
     @Test func map() {
       assertQuery(Reminder.limit(1).select { ($0.id, $0.title) }.map { ($1, $0) }) {
         """


### PR DESCRIPTION
While technically a breaking change for folks specifying the parameter, the parameter wasn't really useful on its own without reaching out to global columns state, so I think it's safe to fix these APIs and consider the previous behavior a bug.