### PR TITLE
Add primary associated type to PrimaryKeyedTable.

### DIFF
--- a/Sources/StructuredQueriesCore/PrimaryKeyed.swift
+++ b/Sources/StructuredQueriesCore/PrimaryKeyed.swift
@@ -1,5 +1,11 @@
 /// A type representing a database table with a primary key.
-public protocol PrimaryKeyedTable: Table where TableColumns: PrimaryKeyedTableDefinition {
+public protocol PrimaryKeyedTable<PrimaryKey>: Table where TableColumns: PrimaryKeyedTableDefinition<PrimaryKey> {
+  /// A type representing this table's primary key.
+  ///
+  /// For auto-incrementing tables, this is typically `Int`.
+  associatedtype PrimaryKey: QueryBindable
+  where PrimaryKey.QueryValue == PrimaryKey, PrimaryKey.QueryValue.QueryOutput: Sendable
+
   /// A type that represents this type, but with an optional primary key.
   ///
   /// This type can be used to stage an inserted row.


### PR DESCRIPTION
This will be useful for our CloudKit work in SharingGRDB.