### PR TITLE
Remove trailing comma

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       matrix:
         swift:
+          - '6.0'
           - '6.1'
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}

--- a/Sources/StructuredQueriesCore/Internal/Deprecations.swift
+++ b/Sources/StructuredQueriesCore/Internal/Deprecations.swift
@@ -53,7 +53,7 @@ extension Table {
     or conflictResolution: ConflictResolution? = nil,
     _ columns: (TableColumns) -> (TableColumn<Self, V1>, repeat TableColumn<Self, each V2>),
     select selection: () -> Select<(C1, repeat each C2), From, Joins>,
-    onConflict updates: ((inout Updates<Self>) -> Void)?,
+    onConflict updates: ((inout Updates<Self>) -> Void)?
   ) -> InsertOf<Self>
   where C1.QueryValue == V1, (repeat (each C2).QueryValue) == (repeat each V2) {
     insert(or: conflictResolution, columns, select: selection, onConflictDoUpdate: updates)


### PR DESCRIPTION
Since we still support Swift 6.0 we can't yet use trailing commas.