### PR TITLE
Generic min max

### DIFF
--- a/Sources/StructuredQueriesCore/AggregateFunctions.swift
+++ b/Sources/StructuredQueriesCore/AggregateFunctions.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension QueryExpression where QueryValue: QueryBindable {
   /// A count aggregate of this expression.
   ///

--- a/Sources/StructuredQueriesCore/AggregateFunctions.swift
+++ b/Sources/StructuredQueriesCore/AggregateFunctions.swift
@@ -84,7 +84,7 @@ where QueryValue: _OptionalPromotable, QueryValue._Optionalized.Wrapped == Strin
   }
 }
 
-extension QueryExpression where QueryValue: QueryBindable {
+extension QueryExpression where QueryValue: QueryBindable & _OptionalPromotable {
   /// A maximum aggregate of this expression.
   ///
   /// ```swift
@@ -96,7 +96,7 @@ extension QueryExpression where QueryValue: QueryBindable {
   /// - Returns: A maximum aggregate of this expression.
   public func max(
     filter: (some QueryExpression<Bool>)? = Bool?.none
-  ) -> some QueryExpression<QueryValue> {
+  ) -> some QueryExpression<QueryValue._Optionalized.Wrapped?> {
     AggregateFunction("max", [queryFragment], filter: filter?.queryFragment)
   }
 
@@ -112,7 +112,7 @@ extension QueryExpression where QueryValue: QueryBindable {
   /// - Returns: A minimum aggregate of this expression.
   public func min(
     filter: (some QueryExpression<Bool>)? = Bool?.none
-  ) -> some QueryExpression<QueryValue> {
+  ) -> some QueryExpression<QueryValue._Optionalized.Wrapped?> {
     AggregateFunction("min", [queryFragment], filter: filter?.queryFragment)
   }
 }
@@ -171,7 +171,7 @@ where QueryValue: _OptionalPromotable, QueryValue._Optionalized.Wrapped: Numeric
   ///
   /// ```swift
   /// Item.select { $0.price.total() }
-  /// // SELECT sum("items"."price") FROM "items"
+  /// // SELECT total("items"."price") FROM "items"
   /// ```
   ///
   /// - Parameters:

--- a/Sources/StructuredQueriesCore/AggregateFunctions.swift
+++ b/Sources/StructuredQueriesCore/AggregateFunctions.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension QueryExpression where QueryValue: QueryBindable {
   /// A count aggregate of this expression.
   ///
@@ -96,9 +98,10 @@ extension QueryExpression where QueryValue: QueryBindable {
   /// - Returns: A maximum aggregate of this expression.
   public func max(
     filter: (some QueryExpression<Bool>)? = Bool?.none
-  ) -> some QueryExpression<Int?> {
+  ) -> some QueryExpression<QueryValue> {
     AggregateFunction("max", [queryFragment], filter: filter?.queryFragment)
   }
+
 
   /// A minimum aggregate of this expression.
   ///
@@ -111,7 +114,7 @@ extension QueryExpression where QueryValue: QueryBindable {
   /// - Returns: A minimum aggregate of this expression.
   public func min(
     filter: (some QueryExpression<Bool>)? = Bool?.none
-  ) -> some QueryExpression<Int?> {
+  ) -> some QueryExpression<QueryValue> {
     AggregateFunction("min", [queryFragment], filter: filter?.queryFragment)
   }
 }

--- a/Tests/StructuredQueriesTests/AggregateFunctionsTests.swift
+++ b/Tests/StructuredQueriesTests/AggregateFunctionsTests.swift
@@ -112,6 +112,21 @@ extension SnapshotTests {
         """
       }
     }
+	  
+	@Test func maxDate() {
+	  assertQuery(Reminder.select { $0.dueDate.max() }) {
+	    """
+	    SELECT max("reminders"."dueDate")
+	    FROM "reminders"
+	    """
+	  }results: {
+	    """
+	    ┌────────────────────────────────┐
+	    │ Date(2001-01-05T00:00:00.000Z) │
+	    └────────────────────────────────┘
+	    """
+	  }
+	}
 
     @Test func min() {
       assertInlineSnapshot(of: User.columns.id.min(), as: .sql) {
@@ -126,12 +141,27 @@ extension SnapshotTests {
         """
       } results: {
         """
-        ┌───┐
-        │ 1 │
-        └───┘
+        ┌──────┐
+        │ .low │
+        └──────┘
         """
       }
     }
+	  
+	@Test func minDate() {
+		assertQuery(Reminder.select { $0.dueDate.min() }) {
+		  """
+		  SELECT min("reminders"."dueDate")
+		  FROM "reminders"
+		  """
+		} results: {
+		  """
+		  ┌────────────────────────────────┐
+		  │ Date(2000-06-25T00:00:00.000Z) │
+		  └────────────────────────────────┘
+		  """
+		}
+	}
 
     @Test func sum() {
       assertInlineSnapshot(of: User.columns.id.sum(), as: .sql) {

--- a/Tests/StructuredQueriesTests/AggregateFunctionsTests.swift
+++ b/Tests/StructuredQueriesTests/AggregateFunctionsTests.swift
@@ -13,6 +13,7 @@ extension SnapshotTests {
       var name: String
       var isAdmin: Bool
       var age: Int?
+      var birthDate: Date?
     }
 
     @Test func average() {
@@ -93,27 +94,12 @@ extension SnapshotTests {
       }
     }
 
-    @Test func max() {
-      assertInlineSnapshot(of: User.columns.id.max(), as: .sql) {
-        """
-        max("users"."id")
-        """
-      }
-      assertQuery(Reminder.select { $0.id.max() }) {
-        """
-        SELECT max("reminders"."id")
-        FROM "reminders"
-        """
-      } results: {
-        """
-        ┌────┐
-        │ 10 │
-        └────┘
-        """
-      }
-    }
-	  
-	@Test func maxDate() {
+	@Test func max() {
+	  assertInlineSnapshot(of: User.columns.birthDate.max(), as: .sql) {
+	    """
+	    max("users"."birthDate")
+	    """
+	  }
 	  assertQuery(Reminder.select { $0.dueDate.max() }) {
 	    """
 	    SELECT max("reminders"."dueDate")
@@ -127,40 +113,25 @@ extension SnapshotTests {
 	    """
 	  }
 	}
-
-    @Test func min() {
-      assertInlineSnapshot(of: User.columns.id.min(), as: .sql) {
-        """
-        min("users"."id")
-        """
-      }
-      assertQuery(Reminder.select { $0.priority.min() }) {
-        """
-        SELECT min("reminders"."priority")
-        FROM "reminders"
-        """
-      } results: {
-        """
-        ┌──────┐
-        │ .low │
-        └──────┘
-        """
-      }
-    }
 	  
-	@Test func minDate() {
-		assertQuery(Reminder.select { $0.dueDate.min() }) {
-		  """
-		  SELECT min("reminders"."dueDate")
-		  FROM "reminders"
-		  """
-		} results: {
-		  """
-		  ┌────────────────────────────────┐
-		  │ Date(2000-06-25T00:00:00.000Z) │
-		  └────────────────────────────────┘
-		  """
-		}
+	@Test func min() {
+	  assertInlineSnapshot(of: User.columns.birthDate.min(), as: .sql) {
+	    """
+	    min("users"."birthDate")
+	    """
+	 }
+	 assertQuery(Reminder.select { $0.dueDate.min() }) {
+	   """
+	   SELECT min("reminders"."dueDate")
+	   FROM "reminders"
+	   """
+	 } results: {
+	   """
+	   ┌────────────────────────────────┐
+	   │ Date(2000-06-25T00:00:00.000Z) │
+	   └────────────────────────────────┘
+	   """
+	  }
 	}
 
     @Test func sum() {

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -1312,7 +1312,7 @@ extension SnapshotTests {
         }
       }
       do {
-        let query: some Statement<Int?> = Reminder.select { $0.priority.flatMap { $0.max() } }
+        let query: some Statement<Priority?> = Reminder.select { $0.priority.flatMap { $0.max() } }
         assertQuery(query) {
           """
           SELECT max("reminders"."priority")
@@ -1320,9 +1320,9 @@ extension SnapshotTests {
           """
         } results: {
           """
-          ┌───┐
-          │ 3 │
-          └───┘
+          ┌───────┐
+          │ .high │
+          └───────┘
           """
         }
       }


### PR DESCRIPTION
Not sure if this breaks anything down the line, all tests passed for me and the output for min/max on date looked realistic. I did notice the snapshot changed to .low for priotity, but given that total works the same way on QueryValue it seemed to be a sensible change. 

Would note that either way the docs use date as an example for min(), which when optional Int tends to some odd results.

Noticed this when trying to use min aggregate on a date column