### PR TITLE
Improve `group(by:)` ergonomics

### DIFF
--- a/Sources/StructuredQueries/Macros.swift
+++ b/Sources/StructuredQueries/Macros.swift
@@ -132,3 +132,10 @@ public macro sql<QueryValue>(
   as queryValueType: QueryValue.Type = QueryValue.self
 ) -> SQLQueryExpression<QueryValue> =
   #externalMacro(module: "StructuredQueriesMacros", type: "SQLMacro")
+
+@freestanding(expression)
+public macro sql(
+  _ queryFragment: QueryFragment,
+  as queryValueType: Any.Type = Any.self
+) -> SQLQueryExpression<Any> =
+  #externalMacro(module: "StructuredQueriesMacros", type: "SQLMacro")

--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -212,7 +212,7 @@ extension Table {
   /// - Returns: A select statement that groups by the given column.
   public static func group<C: QueryExpression>(
     by grouping: (TableColumns) -> C
-  ) -> SelectOf<Self> where C.QueryValue: QueryDecodable {
+  ) -> SelectOf<Self> {
     Where().group(by: grouping)
   }
 
@@ -226,12 +226,7 @@ extension Table {
     each C3: QueryExpression
   >(
     by grouping: (TableColumns) -> (C1, C2, repeat each C3)
-  ) -> SelectOf<Self>
-  where
-    C1.QueryValue: QueryDecodable,
-    C2.QueryValue: QueryDecodable,
-    repeat (each C3).QueryValue: QueryDecodable
-  {
+  ) -> SelectOf<Self> {
     Where().group(by: grouping)
   }
 
@@ -1182,8 +1177,7 @@ extension Select {
   /// - Returns: A new select statement that groups by the given column.
   public func group<C: QueryExpression, each J: Table>(
     by grouping: (From.TableColumns, repeat (each J).TableColumns) -> C
-  ) -> Self
-  where C.QueryValue: QueryDecodable, Joins == (repeat each J) {
+  ) -> Self where Joins == (repeat each J) {
     _group(by: grouping)
   }
 
@@ -1199,13 +1193,7 @@ extension Select {
     each J: Table
   >(
     by grouping: (From.TableColumns, repeat (each J).TableColumns) -> (C1, C2, repeat each C3)
-  ) -> Self
-  where
-    C1.QueryValue: QueryDecodable,
-    C2.QueryValue: QueryDecodable,
-    repeat (each C3).QueryValue: QueryDecodable,
-    Joins == (repeat each J)
-  {
+  ) -> Self where Joins == (repeat each J) {
     _group(by: grouping)
   }
 
@@ -1214,11 +1202,7 @@ extension Select {
     each J: Table
   >(
     by grouping: (From.TableColumns, repeat (each J).TableColumns) -> (repeat each C)
-  ) -> Self
-  where
-    repeat (each C).QueryValue: QueryDecodable,
-    Joins == (repeat each J)
-  {
+  ) -> Self where Joins == (repeat each J) {
     var select = self
     select.group
       .append(

--- a/Sources/StructuredQueriesCore/Statements/Where.swift
+++ b/Sources/StructuredQueriesCore/Statements/Where.swift
@@ -387,22 +387,16 @@ extension Where: SelectStatement {
   }
 
   /// A select statement for the filtered table grouped by the given column.
-  public func group<C: QueryExpression>(by grouping: (From.TableColumns) -> C) -> Select<
-    (), From, ()
-  >
-  where C.QueryValue: QueryDecodable {
+  public func group<C: QueryExpression>(
+    by grouping: (From.TableColumns) -> C
+  ) -> Select<(), From, ()> {
     asSelect().group(by: grouping)
   }
 
   /// A select statement for the filtered table grouped by the given columns.
   public func group<C1: QueryExpression, C2: QueryExpression, each C3: QueryExpression>(
     by grouping: (From.TableColumns) -> (C1, C2, repeat each C3)
-  ) -> SelectOf<From>
-  where
-    C1.QueryValue: QueryDecodable,
-    C2.QueryValue: QueryDecodable,
-    repeat (each C3).QueryValue: QueryDecodable
-  {
+  ) -> SelectOf<From> {
     asSelect().group(by: grouping)
   }
 

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -644,6 +644,23 @@ extension SnapshotTests {
         └───────┴───┘
         """
       }
+
+      assertQuery(
+        Reminder.select { ($0.isCompleted, $0.id.count()) }.group { #sql("\($0.isCompleted)") }
+      ) {
+        """
+        SELECT "reminders"."isCompleted", count("reminders"."id")
+        FROM "reminders"
+        GROUP BY "reminders"."isCompleted"
+        """
+      } results: {
+        """
+        ┌───────┬───┐
+        │ false │ 7 │
+        │ true  │ 3 │
+        └───────┴───┘
+        """
+      }
     }
 
     @Test func having() {


### PR DESCRIPTION
This PR allows the following to work without qualifying the expression type:

```diff
 Reminder.group {
-  #sql("date(\($0.dueDate))", as: Date?.self)
+  #sql("date(\($0.dueDate))")
 }
```