### PR TITLE
Add `QueryExpression<Optional>.map,flatMap`

### DIFF
--- a/Sources/StructuredQueriesCore/Documentation.docc/Extensions/QueryExpression.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Extensions/QueryExpression.md
@@ -28,3 +28,8 @@
 
 - ``jsonArrayLength()``
 - ``jsonGroupArray(order:filter:)``
+
+### Optionality
+
+- ``map(_:)``
+- ``flatMap(_:)``

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -1153,6 +1153,50 @@ extension SnapshotTests {
         """
       }
     }
+
+    @Test func optionalMapAndFlatMap() {
+      do {
+        let query: some Statement<Bool?> = Reminder.select {
+          $0.priority.map { $0 < Priority.high }
+        }
+        assertQuery(query) {
+          """
+          SELECT ("reminders"."priority" < 3)
+          FROM "reminders"
+          """
+        } results: {
+          """
+          ┌───────┐
+          │ nil   │
+          │ nil   │
+          │ false │
+          │ nil   │
+          │ nil   │
+          │ false │
+          │ true  │
+          │ false │
+          │ nil   │
+          │ true  │
+          └───────┘
+          """
+        }
+      }
+      do {
+        let query: some Statement<Int?> = Reminder.select { $0.priority.flatMap { $0.max() } }
+        assertQuery(query) {
+          """
+          SELECT max("reminders"."priority")
+          FROM "reminders"
+          """
+        } results: {
+          """
+          ┌───┐
+          │ 3 │
+          └───┘
+          """
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds helpers that make it a little easier to work with optional query expressions in a builder.

For example, if you want to execute a `LIKE` operator on an optional string, you currently have to resort to one of the following workarounds, that either muddy the underlying SQL or require escape hatches outside the type system:

```swift
.where { ($0.title ?? "").like("%foo%") }
// WHERE coalesce("title", '') LIKE '%foo%'

.where { #sql("\($0.title) LIKE '%foo%'") }
// WHERE "title" LIKE '%foo%'
```

This PR introduces `map` and `flatMap` operations on optional `QueryExpression`s that unwraps the expression, giving you additional flexibility in how you express your builder code:

```swift
.where { $0.title.map { $0.like("%foo%") } ?? false }
// WHERE coalesce("title" LIKE '%foo%', 0)
```

While this is more code than the above options, some may prefer its readability, and should we merge the other optional helpers from #61, it could be further shortened:

```swift
.where { $0.title.map { $0.like("%foo%") } }
// WHERE "title" LIKE '%foo%'
```