### PR TITLE
Fix binding sequence number

### DIFF
--- a/Sources/StructuredQueriesCore/QueryFragment.swift
+++ b/Sources/StructuredQueriesCore/QueryFragment.swift
@@ -69,7 +69,7 @@ public struct QueryFragment: Hashable, Sendable {
       case .sql(let sql):
         $0.sql.append(sql)
       case .binding(let binding):
-        $0.sql.append(template($1.offset + 1))
+        $0.sql.append(template($0.bindings.count + 1))
         $0.bindings.append(binding)
       }
     }


### PR DESCRIPTION
```
@Table
struct Reminder {
  let id: Int
  var title = ""
  var isCompleted = false
  var priority: Int?
  var dueDate: Date?
}

let query =  Reminder.where {$0.title == "Test" }
let (sql, bindings) = query.query.prepare{ "$\($0)" }
```
Before:
`SELECT "reminders"."id", "reminders"."title", "reminders"."isCompleted", "reminders"."priority", "reminders"."dueDate" FROM "reminders" WHERE ("reminders"."title" = $52)`

After:
`SELECT "reminders"."id", "reminders"."title", "reminders"."isCompleted", "reminders"."priority", "reminders"."dueDate" FROM "reminders" WHERE ("reminders"."title" = $1)`