### PR TITLE
Expected empty string to not throw error for optional

### DIFF
--- a/Tests/StructuredQueriesTests/DecodingTests.swift
+++ b/Tests/StructuredQueriesTests/DecodingTests.swift
@@ -73,6 +73,18 @@ extension SnapshotTests {
         )
         .first == .high
       )
+      #expect(
+        try db.execute(
+          SimpleSelect { #sql("", as: Priority?.self) }
+        )
+        .first == .some(.none)
+      )
+      #expect(
+        try db.execute(
+          SimpleSelect { #sql("NULL", as: Priority?.self) }
+        )
+        .first == .some(.none)
+      )
     }
 
     @Test func queryRepresentable() throws {


### PR DESCRIPTION
See Slack conversation [here](https://pointfreecommunity.slack.com/archives/C08J4DTE0TC/p1750717738804749)

`NULL` works fine, but empty string throws error.