### PR TITLE
An alternate implementation of `excluded` conflict resolution

### DIFF
--- a/Sources/StructuredQueriesCore/Documentation.docc/Extensions/Update.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Extensions/Update.md
@@ -14,5 +14,4 @@
 
 - ``UpdateOf``
 - ``Updates``
-- ``UpdatesOf``
 - ``ConflictResolution``

--- a/Sources/StructuredQueriesCore/Internal/Deprecations.swift
+++ b/Sources/StructuredQueriesCore/Internal/Deprecations.swift
@@ -45,7 +45,7 @@ extension Table {
   public static func insert(
     or conflictResolution: ConflictResolution? = nil,
     _ row: Self,
-    onConflict doUpdate: ((inout Updates<Self, Excluded>) -> Void)? = nil
+    onConflict doUpdate: ((inout Updates<Self>) -> Void)? = nil
   ) -> InsertOf<Self> {
     insert(or: conflictResolution, [row], onConflict: doUpdate)
   }
@@ -56,7 +56,7 @@ extension Table {
   public static func insert(
     or conflictResolution: ConflictResolution? = nil,
     _ rows: [Self],
-    onConflict doUpdate: ((inout Updates<Self, Excluded>) -> Void)? = nil
+    onConflict doUpdate: ((inout Updates<Self>) -> Void)? = nil
   ) -> InsertOf<Self> {
     insert(or: conflictResolution, values: { rows }, onConflict: doUpdate)
   }
@@ -66,7 +66,7 @@ extension Table {
     or conflictResolution: ConflictResolution? = nil,
     _ columns: (TableColumns) -> TableColumns = { $0 },
     @InsertValuesBuilder<Self> values: () -> [Self],
-    onConflict updates: ((inout Updates<Self, Excluded>) -> Void)?
+    onConflict updates: ((inout Updates<Self>) -> Void)?
   ) -> InsertOf<Self> {
     insert(or: conflictResolution, columns, values: values, onConflictDoUpdate: updates)
   }
@@ -77,7 +77,7 @@ extension Table {
     _ columns: (TableColumns) -> (TableColumn<Self, V1>, repeat TableColumn<Self, each V2>),
     @InsertValuesBuilder<(V1.QueryOutput, repeat (each V2).QueryOutput)>
     values: () -> [(V1.QueryOutput, repeat (each V2).QueryOutput)],
-    onConflict updates: ((inout Updates<Self, Excluded>) -> Void)?
+    onConflict updates: ((inout Updates<Self>) -> Void)?
   ) -> InsertOf<Self> {
     insert(or: conflictResolution, columns, values: values, onConflictDoUpdate: updates)
   }
@@ -89,7 +89,7 @@ extension Table {
     or conflictResolution: ConflictResolution? = nil,
     _ columns: (TableColumns) -> (TableColumn<Self, V1>, repeat TableColumn<Self, each V2>),
     select selection: () -> Select<(V1, repeat each V2), From, Joins>,
-    onConflict updates: ((inout Updates<Self, Excluded>) -> Void)?
+    onConflict updates: ((inout Updates<Self>) -> Void)?
   ) -> InsertOf<Self> {
     insert(or: conflictResolution, columns, select: selection, onConflictDoUpdate: updates)
   }
@@ -102,7 +102,7 @@ extension PrimaryKeyedTable {
   public static func insert(
     or conflictResolution: ConflictResolution? = nil,
     _ row: Draft,
-    onConflict updates: ((inout Updates<Self, Excluded>) -> Void)? = nil
+    onConflict updates: ((inout Updates<Self>) -> Void)? = nil
   ) -> InsertOf<Self> {
     insert(or: conflictResolution, values: { row }, onConflictDoUpdate: updates)
   }
@@ -113,7 +113,7 @@ extension PrimaryKeyedTable {
   public static func insert(
     or conflictResolution: ConflictResolution? = nil,
     _ rows: [Draft],
-    onConflict updates: ((inout Updates<Self, Excluded>) -> Void)? = nil
+    onConflict updates: ((inout Updates<Self>) -> Void)? = nil
   ) -> InsertOf<Self> {
     insert(or: conflictResolution, values: { rows }, onConflictDoUpdate: updates)
   }

--- a/Sources/StructuredQueriesCore/Statements/Insert.swift
+++ b/Sources/StructuredQueriesCore/Statements/Insert.swift
@@ -58,7 +58,7 @@ extension Table {
     or conflictResolution: ConflictResolution? = nil,
     _ columns: (TableColumns) -> TableColumns = { $0 },
     @InsertValuesBuilder<Self> values: () -> [Self],
-    onConflictDoUpdate updates: ((inout Updates<Self, Excluded>) -> Void)? = nil,
+    onConflictDoUpdate updates: ((inout Updates<Self>, Excluded) -> Void)? = nil,
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -68,6 +68,72 @@ extension Table {
       onConflict: { _ -> ()? in nil },
       where: { _ in return [] },
       doUpdate: updates,
+      where: updateFilter
+    )
+  }
+
+  /// An insert statement for one or more table rows.
+  ///
+  /// This function can be used to create an insert statement from a ``Table`` value.
+  ///
+  /// ```swift
+  /// let tag = Tag(title: "car")
+  /// Tag.insert { tag }
+  /// // INSERT INTO "tags" ("title")
+  /// // VALUES ('car')
+  /// ```
+  ///
+  /// It can also be used to insert multiple rows in a single statement.
+  ///
+  /// ```swift
+  /// let tags = [
+  ///   Tag(title: "car"),
+  ///   Tag(title: "kids"),
+  ///   Tag(title: "someday"),
+  ///   Tag(title: "optional")
+  /// ]
+  /// Tag.insert { tags }
+  /// // INSERT INTO "tags" ("title")
+  /// // VALUES ('car'), ('kids'), ('someday'), ('optional')
+  /// ```
+  ///
+  /// The `values` trailing closure is a result builder that will insert any number of expressions,
+  /// one after the other, and supports basic control flow statements.
+  ///
+  /// ```swift
+  /// Tag.insert {
+  ///   if vehicleOwner {
+  ///     Tag(name: "car")
+  ///   }
+  ///   Tag(name: "kids")
+  ///   Tag(name: "someday")
+  ///   Tag(name: "optional")
+  /// }
+  /// // INSERT INTO "tags" ("title")
+  /// // VALUES ('car'), ('kids'), ('someday'), ('optional')
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - conflictResolution: A conflict resolution algorithm.
+  ///   - columns: Columns to insert.
+  ///   - values: A builder of row values for the given columns.
+  ///   - updates: Updates to perform in an upsert clause should the insert conflict with an
+  ///     existing row.
+  ///   - updateFilter: A filter to apply to the update clause.
+  /// - Returns: An insert statement.
+  public static func insert(
+    or conflictResolution: ConflictResolution? = nil,
+    _ columns: (TableColumns) -> TableColumns = { $0 },
+    @InsertValuesBuilder<Self> values: () -> [Self],
+    onConflictDoUpdate updates: ((inout Updates<Self>) -> Void)?,
+    @QueryFragmentBuilder<Bool>
+    where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
+  ) -> InsertOf<Self> {
+    insert(
+      or: conflictResolution,
+      columns,
+      values: values,
+      onConflictDoUpdate: updates.map { updates in { row, _ in updates(&row) } },
       where: updateFilter
     )
   }
@@ -93,7 +159,7 @@ extension Table {
     ),
     @QueryFragmentBuilder<Bool>
     where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
-    doUpdate updates: (inout Updates<Self, Excluded>) -> Void = { _ in },
+    doUpdate updates: (inout Updates<Self>, Excluded) -> Void = { _, _ in },
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -109,13 +175,49 @@ extension Table {
     }
   }
 
+  /// An upsert statement for one or more table rows.
+  ///
+  /// - Parameters:
+  ///   - conflictResolution: A conflict resolution algorithm.
+  ///   - columns: Columns to insert.
+  ///   - values: A builder of row values for the given columns.
+  ///   - conflictTargets: Indexed columns to target for conflict resolution.
+  ///   - targetFilter: A filter to apply to conflict target columns.
+  ///   - updates: Updates to perform in an upsert clause should the insert conflict with an
+  ///     existing row.
+  ///   - updateFilter: A filter to apply to the update clause.
+  /// - Returns: An insert statement.
+  public static func insert<T1, each T2>(
+    or conflictResolution: ConflictResolution? = nil,
+    _ columns: (TableColumns) -> TableColumns = { $0 },
+    @InsertValuesBuilder<Self> values: () -> [Self],
+    onConflict conflictTargets: (TableColumns) -> (
+      TableColumn<Self, T1>, repeat TableColumn<Self, each T2>
+    ),
+    @QueryFragmentBuilder<Bool>
+    where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
+    doUpdate updates: (inout Updates<Self>) -> Void,
+    @QueryFragmentBuilder<Bool>
+    where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
+  ) -> InsertOf<Self> {
+    insert(
+      or: conflictResolution,
+      columns,
+      values: values,
+      onConflict: conflictTargets,
+      where: targetFilter,
+      doUpdate: { row, _ in updates(&row) },
+      where: updateFilter
+    )
+  }
+
   private static func _insert<each ConflictTarget>(
     or conflictResolution: ConflictResolution?,
     @InsertValuesBuilder<Self> values: () -> [Self],
     onConflict conflictTargets: (TableColumns) -> (repeat TableColumn<Self, each ConflictTarget>)?,
     @QueryFragmentBuilder<Bool>
     where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
-    doUpdate updates: ((inout Updates<Self, Excluded>) -> Void)?,
+    doUpdate updates: ((inout Updates<Self>, Excluded) -> Void)?,
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -201,7 +303,7 @@ extension Table {
     _ columns: (TableColumns) -> (TableColumn<Self, V1>, repeat TableColumn<Self, each V2>),
     @InsertValuesBuilder<(V1.QueryOutput, repeat (each V2).QueryOutput)>
     values: () -> [(V1.QueryOutput, repeat (each V2).QueryOutput)],
-    onConflictDoUpdate updates: ((inout Updates<Self, Excluded>) -> Void)? = nil,
+    onConflictDoUpdate updates: ((inout Updates<Self>, Excluded) -> Void)? = nil,
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -212,6 +314,34 @@ extension Table {
       onConflict: { _ -> ()? in nil },
       where: { _ in return [] },
       doUpdate: updates,
+      where: updateFilter
+    )
+  }
+
+  /// An insert statement for one or more table rows.
+  ///
+  /// - Parameters:
+  ///   - conflictResolution: A conflict resolution algorithm.
+  ///   - columns: Columns to insert.
+  ///   - values: A builder of row values for the given columns.
+  ///   - updates: Updates to perform in an upsert clause should the insert conflict with an
+  ///     existing row.
+  ///   - updateFilter: A filter to apply to the update clause.
+  /// - Returns: An insert statement.
+  public static func insert<V1, each V2>(
+    or conflictResolution: ConflictResolution? = nil,
+    _ columns: (TableColumns) -> (TableColumn<Self, V1>, repeat TableColumn<Self, each V2>),
+    @InsertValuesBuilder<(V1.QueryOutput, repeat (each V2).QueryOutput)>
+    values: () -> [(V1.QueryOutput, repeat (each V2).QueryOutput)],
+    onConflictDoUpdate updates: ((inout Updates<Self>) -> Void)?,
+    @QueryFragmentBuilder<Bool>
+    where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
+  ) -> InsertOf<Self> {
+    insert(
+      or: conflictResolution,
+      columns,
+      values: values,
+      onConflictDoUpdate: updates.map { updates in { row, _ in updates(&row) } },
       where: updateFilter
     )
   }
@@ -238,7 +368,7 @@ extension Table {
     ),
     @QueryFragmentBuilder<Bool>
     where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
-    doUpdate updates: (inout Updates<Self, Excluded>) -> Void = { _ in },
+    doUpdate updates: (inout Updates<Self>, Excluded) -> Void = { _, _ in },
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -255,6 +385,43 @@ extension Table {
     }
   }
 
+  /// An upsert statement for one or more table rows.
+  ///
+  /// - Parameters:
+  ///   - conflictResolution: A conflict resolution algorithm.
+  ///   - columns: Columns to insert.
+  ///   - values: A builder of row values for the given columns.
+  ///   - conflictTargets: Indexed columns to target for conflict resolution.
+  ///   - targetFilter: A filter to apply to conflict target columns.
+  ///   - updates: Updates to perform in an upsert clause should the insert conflict with an
+  ///     existing row.
+  ///   - updateFilter: A filter to apply to the update clause.
+  /// - Returns: An insert statement.
+  public static func insert<V1, each V2, T1, each T2>(
+    or conflictResolution: ConflictResolution? = nil,
+    _ columns: (TableColumns) -> (TableColumn<Self, V1>, repeat TableColumn<Self, each V2>),
+    @InsertValuesBuilder<(V1.QueryOutput, repeat (each V2).QueryOutput)>
+    values: () -> [(V1.QueryOutput, repeat (each V2).QueryOutput)],
+    onConflict conflictTargets: (TableColumns) -> (
+      TableColumn<Self, T1>, repeat TableColumn<Self, each T2>
+    ),
+    @QueryFragmentBuilder<Bool>
+    where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
+    doUpdate updates: (inout Updates<Self>) -> Void,
+    @QueryFragmentBuilder<Bool>
+    where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
+  ) -> InsertOf<Self> {
+    insert(
+      or: conflictResolution,
+      columns,
+      values: values,
+      onConflict: conflictTargets,
+      where: targetFilter,
+      doUpdate: { row, _ in updates(&row) },
+      where: updateFilter
+    )
+  }
+
   private static func _insert<each Value, each ConflictTarget>(
     or conflictResolution: ConflictResolution?,
     _ columns: (TableColumns) -> (repeat TableColumn<Self, each Value>),
@@ -263,7 +430,7 @@ extension Table {
     onConflict conflictTargets: (TableColumns) -> (repeat TableColumn<Self, each ConflictTarget>)?,
     @QueryFragmentBuilder<Bool>
     where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
-    doUpdate updates: ((inout Updates<Self, Excluded>) -> Void)?,
+    doUpdate updates: ((inout Updates<Self>, Excluded) -> Void)?,
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -310,7 +477,7 @@ extension Table {
     or conflictResolution: ConflictResolution? = nil,
     _ columns: (TableColumns) -> (TableColumn<Self, V1>, repeat TableColumn<Self, each V2>),
     select selection: () -> some PartialSelectStatement<(V1, repeat each V2)>,
-    onConflictDoUpdate updates: ((inout Updates<Self, Excluded>) -> Void)? = nil,
+    onConflictDoUpdate updates: ((inout Updates<Self>, Excluded) -> Void)? = nil,
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -321,6 +488,39 @@ extension Table {
       onConflict: { _ -> ()? in nil },
       where: { _ in return [] },
       doUpdate: updates,
+      where: updateFilter
+    )
+  }
+
+  /// An insert statement for a table selection.
+  ///
+  /// This function can be used to create an insert statement for the results of a ``Select``
+  /// statement.
+  ///
+  /// - Parameters:
+  ///   - conflictResolution: A conflict resolution algorithm.
+  ///   - columns: Columns values to be inserted.
+  ///   - selection: A statement that selects the values to be inserted.
+  ///   - updates: Updates to perform in an upsert clause should the insert conflict with an
+  ///     existing row.
+  ///   - updateFilter: A filter to apply to the update clause.
+  /// - Returns: An insert statement.
+  public static func insert<
+    V1,
+    each V2
+  >(
+    or conflictResolution: ConflictResolution? = nil,
+    _ columns: (TableColumns) -> (TableColumn<Self, V1>, repeat TableColumn<Self, each V2>),
+    select selection: () -> some PartialSelectStatement<(V1, repeat each V2)>,
+    onConflictDoUpdate updates: ((inout Updates<Self>) -> Void)?,
+    @QueryFragmentBuilder<Bool>
+    where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
+  ) -> InsertOf<Self> {
+    insert(
+      or: conflictResolution,
+      columns,
+      select: selection,
+      onConflictDoUpdate: updates.map { updates in { row, _ in updates(&row) } },
       where: updateFilter
     )
   }
@@ -354,7 +554,7 @@ extension Table {
     ),
     @QueryFragmentBuilder<Bool>
     where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
-    doUpdate updates: (inout Updates<Self, Excluded>) -> Void = { _ in },
+    doUpdate updates: (inout Updates<Self>, Excluded) -> Void = { _, _ in },
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -371,6 +571,50 @@ extension Table {
     }
   }
 
+  /// An insert statement for a table selection.
+  ///
+  /// This function can be used to create an insert statement for the results of a ``Select``
+  /// statement.
+  ///
+  /// - Parameters:
+  ///   - conflictResolution: A conflict resolution algorithm.
+  ///   - columns: Columns values to be inserted.
+  ///   - selection: A statement that selects the values to be inserted.
+  ///   - conflictTargets: Indexed columns to target for conflict resolution.
+  ///   - targetFilter: A filter to apply to conflict target columns.
+  ///   - updates: Updates to perform in an upsert clause should the insert conflict with an
+  ///     existing row.
+  ///   - updateFilter: A filter to apply to the update clause.
+  /// - Returns: An insert statement.
+  public static func insert<
+    V1,
+    each V2,
+    T1,
+    each T2
+  >(
+    or conflictResolution: ConflictResolution? = nil,
+    _ columns: (TableColumns) -> (TableColumn<Self, V1>, repeat TableColumn<Self, each V2>),
+    select selection: () -> some PartialSelectStatement<(V1, repeat each V2)>,
+    onConflict conflictTargets: (TableColumns) -> (
+      TableColumn<Self, T1>, repeat TableColumn<Self, each T2>
+    ),
+    @QueryFragmentBuilder<Bool>
+    where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
+    doUpdate updates: (inout Updates<Self>) -> Void,
+    @QueryFragmentBuilder<Bool>
+    where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
+  ) -> InsertOf<Self> {
+    insert(
+      or: conflictResolution,
+      columns,
+      select: selection,
+      onConflict: conflictTargets,
+      where: targetFilter,
+      doUpdate: { row, _ in updates(&row) },
+      where: updateFilter
+    )
+  }
+
   private static func _insert<
     each Value,
     each ConflictTarget
@@ -381,7 +625,7 @@ extension Table {
     onConflict conflictTargets: (TableColumns) -> (repeat TableColumn<Self, each ConflictTarget>)?,
     @QueryFragmentBuilder<Bool>
     where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
-    doUpdate updates: ((inout Updates<Self, Excluded>) -> Void)?,
+    doUpdate updates: ((inout Updates<Self>, Excluded) -> Void)?,
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -432,7 +676,7 @@ extension Table {
     onConflict conflictTargets: (TableColumns) -> (repeat TableColumn<Self, each ConflictTarget>)?,
     @QueryFragmentBuilder<Bool>
     where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
-    doUpdate updates: ((inout Updates<Self, Excluded>) -> Void)?,
+    doUpdate updates: ((inout Updates<Self>, Excluded) -> Void)?,
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -448,7 +692,7 @@ extension Table {
       conflictTargetColumnNames: conflictTargetColumnNames,
       conflictTargetFilter: targetFilter(Self.columns),
       values: values,
-      updates: updates.map { Updates($0, excluded: Excluded.QueryValue.columns) },
+      updates: updates.map { updates in Updates { updates(&$0, Excluded.QueryValue.columns) } },
       updateFilter: updateFilter(Self.columns),
       returning: []
     )
@@ -472,7 +716,7 @@ extension PrimaryKeyedTable {
     or conflictResolution: ConflictResolution? = nil,
     _ columns: (Draft.TableColumns) -> Draft.TableColumns = { $0 },
     @InsertValuesBuilder<Draft> values: () -> [Draft],
-    onConflictDoUpdate updates: ((inout Updates<Self, Excluded>) -> Void)? = nil,
+    onConflictDoUpdate updates: ((inout Updates<Self>, Excluded) -> Void)? = nil,
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -482,6 +726,35 @@ extension PrimaryKeyedTable {
       onConflict: { _ -> ()? in nil },
       where: { _ in return [] },
       doUpdate: updates,
+      where: updateFilter
+    )
+  }
+
+  /// An insert statement for one or more table rows.
+  ///
+  /// This function can be used to create an insert statement from a ``Draft`` value.
+  ///
+  /// - Parameters:
+  ///   - conflictResolution: A conflict resolution algorithm.
+  ///   - columns: Columns to insert.
+  ///   - values: A builder of row values for the given columns.
+  ///   - updates: Updates to perform in an upsert clause should the insert conflict with an
+  ///     existing row.
+  ///   - updateFilter: A filter to apply to the update clause.
+  /// - Returns: An insert statement.
+  public static func insert(
+    or conflictResolution: ConflictResolution? = nil,
+    _ columns: (Draft.TableColumns) -> Draft.TableColumns = { $0 },
+    @InsertValuesBuilder<Draft> values: () -> [Draft],
+    onConflictDoUpdate updates: ((inout Updates<Self>) -> Void)?,
+    @QueryFragmentBuilder<Bool>
+    where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
+  ) -> InsertOf<Self> {
+    insert(
+      or: conflictResolution,
+      columns,
+      values: values,
+      onConflictDoUpdate: updates.map { updates in { row, _ in updates(&row) } },
       where: updateFilter
     )
   }
@@ -508,7 +781,7 @@ extension PrimaryKeyedTable {
     ),
     @QueryFragmentBuilder<Bool>
     where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
-    doUpdate updates: (inout Updates<Self, Excluded>) -> Void = { _ in },
+    doUpdate updates: (inout Updates<Self>, Excluded) -> Void = { _, _ in },
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -523,6 +796,43 @@ extension PrimaryKeyedTable {
       )
     }
   }
+
+  /// An insert statement for one or more table rows.
+  ///
+  /// This function can be used to create an insert statement from a ``Draft`` value.
+  ///
+  /// - Parameters:
+  ///   - conflictResolution: A conflict resolution algorithm.
+  ///   - columns: Columns to insert.
+  ///   - values: A builder of row values for the given columns.
+  ///   - conflictTargets: Indexed columns to target for conflict resolution.
+  ///   - targetFilter: A filter to apply to conflict target columns.
+  ///   - updates: Updates to perform in an upsert clause should the insert conflict with an
+  ///     existing row.
+  ///   - updateFilter: A filter to apply to the update clause.
+  public static func insert<T1, each T2>(
+    or conflictResolution: ConflictResolution? = nil,
+    _ columns: (Draft.TableColumns) -> Draft.TableColumns = { $0 },
+    @InsertValuesBuilder<Draft> values: () -> [Draft],
+    onConflict conflictTargets: (TableColumns) -> (
+      TableColumn<Self, T1>, repeat TableColumn<Self, each T2>
+    ),
+    @QueryFragmentBuilder<Bool>
+    where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
+    doUpdate updates: (inout Updates<Self>) -> Void,
+    @QueryFragmentBuilder<Bool>
+    where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
+  ) -> InsertOf<Self> {
+    insert(
+      or: conflictResolution,
+      values: values,
+      onConflict: conflictTargets,
+      where: targetFilter,
+      doUpdate: { row, _ in updates(&row) },
+      where: updateFilter
+    )
+  }
+
   /// An upsert statement for given drafts.
   ///
   /// Generates an insert statement with an upsert clause. Useful for building forms that can both
@@ -547,7 +857,8 @@ extension PrimaryKeyedTable {
       or: conflictResolution,
       values: values,
       onConflict: { $0.primaryKey },
-      doUpdate: { updates in
+      doUpdate: { updates, excluded in
+        // TODO: Use 'excluded' here?
         for column in Draft.TableColumns.allColumns where column.name != columns.primaryKey.name {
           updates.set(column, #""excluded".\#(quote: column.name)"#)
         }
@@ -561,7 +872,7 @@ extension PrimaryKeyedTable {
     onConflict conflictTargets: (TableColumns) -> (repeat TableColumn<Self, each ConflictTarget>)?,
     @QueryFragmentBuilder<Bool>
     where targetFilter: (TableColumns) -> [QueryFragment] = { _ in [] },
-    doUpdate updates: ((inout Updates<Self, Excluded>) -> Void)?,
+    doUpdate updates: ((inout Updates<Self>, Excluded) -> Void)?,
     @QueryFragmentBuilder<Bool>
     where updateFilter: (TableColumns) -> [QueryFragment] = { _ in [] }
   ) -> InsertOf<Self> {
@@ -607,7 +918,7 @@ public struct Insert<Into: Table, Returning> {
   var conflictTargetColumnNames: [String]
   var conflictTargetFilter: [QueryFragment]
   fileprivate var values: InsertValues
-  var updates: Updates<Into, Into.Excluded>?
+  var updates: Updates<Into>?
   var updateFilter: [QueryFragment]
   var returning: [QueryFragment]
 
@@ -617,7 +928,7 @@ public struct Insert<Into: Table, Returning> {
     conflictTargetColumnNames: [String],
     conflictTargetFilter: [QueryFragment],
     values: InsertValues,
-    updates: Updates<Into, Into.Excluded>?,
+    updates: Updates<Into>?,
     updateFilter: [QueryFragment],
     returning: [QueryFragment]
   ) {

--- a/Sources/StructuredQueriesCore/Statements/Update.swift
+++ b/Sources/StructuredQueriesCore/Statements/Update.swift
@@ -35,7 +35,7 @@ extension Table {
   /// - Returns: An update statement.
   public static func update(
     or conflictResolution: ConflictResolution? = nil,
-    set updates: (inout UpdatesOf<Self>) -> Void
+    set updates: (inout Updates<Self>) -> Void
   ) -> UpdateOf<Self> {
     Update(conflictResolution: conflictResolution, updates: Updates(updates))
   }
@@ -92,7 +92,7 @@ extension PrimaryKeyedTable {
 /// To learn more, see <doc:UpdateStatements>.
 public struct Update<From: Table, Returning> {
   var conflictResolution: ConflictResolution?
-  var updates: UpdatesOf<From>
+  var updates: Updates<From>
   var `where`: [QueryFragment] = []
   var returning: [QueryFragment] = []
 

--- a/Sources/StructuredQueriesCore/Statements/Where.swift
+++ b/Sources/StructuredQueriesCore/Statements/Where.swift
@@ -481,7 +481,7 @@ extension Where: SelectStatement {
   /// - Returns: An update statement.
   public func update(
     or conflictResolution: ConflictResolution? = nil,
-    set updates: (inout UpdatesOf<From>) -> Void
+    set updates: (inout Updates<From>) -> Void
   ) -> UpdateOf<From> {
     Update(
       conflictResolution: conflictResolution,

--- a/Sources/StructuredQueriesCore/Triggers.swift
+++ b/Sources/StructuredQueriesCore/Triggers.swift
@@ -95,7 +95,7 @@ extension Table {
   public static func createTemporaryTrigger(
     _ name: String? = nil,
     ifNotExists: Bool = false,
-    afterUpdateTouch updates: (inout UpdatesOf<Self>) -> Void,
+    afterUpdateTouch updates: (inout Updates<Self>) -> Void,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     column: UInt = #column
@@ -173,7 +173,7 @@ extension Table {
   public static func createTemporaryTrigger(
     _ name: String? = nil,
     ifNotExists: Bool = false,
-    afterInsertTouch updates: (inout UpdatesOf<Self>) -> Void,
+    afterInsertTouch updates: (inout Updates<Self>) -> Void,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     column: UInt = #column

--- a/Sources/StructuredQueriesCore/Updates.swift
+++ b/Sources/StructuredQueriesCore/Updates.swift
@@ -5,18 +5,10 @@
 ///
 /// To learn more, see <doc:UpdateStatements>.
 @dynamicMemberLookup
-public struct Updates<Base: Table, Excluded: Sendable> {
-  /// The value that would have been inserted in an [insert statement](<doc:InsertStatements>) had
-  /// there been no conflict.
-  public let excluded: Excluded
-
+public struct Updates<Base: Table> {
   private var updates: [(String, QueryFragment)] = []
 
-  init(
-    _ body: (inout Self) -> Void,
-    excluded: Excluded = ()
-  ) {
-    self.excluded = excluded
+  init(_ body: (inout Self) -> Void) {
     body(&self)
   }
 
@@ -59,9 +51,6 @@ public struct Updates<Base: Table, Excluded: Sendable> {
     }
   }
 }
-
-/// A convenience type alias for a non-upsert set of updates.
-public typealias UpdatesOf<Base: Table> = Updates<Base, ()>
 
 extension Updates: QueryExpression {
   public typealias QueryValue = Never

--- a/Tests/StructuredQueriesTests/InsertTests.swift
+++ b/Tests/StructuredQueriesTests/InsertTests.swift
@@ -585,7 +585,7 @@ extension SnapshotTests {
         } where: {
           !$0.isCompleted
         } doUpdate: {
-          $0.isCompleted = $0.excluded.isCompleted
+          $0.isCompleted = $1.isCompleted
         } where: {
           $0.isFlagged
         }


### PR DESCRIPTION
This implementation may be the way to go. We can merge it into the other PR branch if we decide to go this direction.

Notably I did keep the overloads for the existing APIs, because it would be annoying to ignore `excluded` when you don't need it and lose out on `$0` shorthand syntax:

```diff
-onConflictDoUpdate: {
-  $0.title += " (Copy)"
+onConflictDoUpdate: { reminder, _ in
+  reminder.title += " (Copy)"
 }
```

So in this PR, it still compiles.