### PR TITLE
Add `PrimaryKeyedTable.primaryKey`

### DIFF
--- a/Sources/StructuredQueriesCore/Documentation.docc/Extensions/PrimaryKeyedTable.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Extensions/PrimaryKeyedTable.md
@@ -125,6 +125,11 @@ Reminder.delete(reminder)
 
 ## Topics
 
+### Primary keys
+
+- ``PrimaryKey``
+- ``primaryKey-swift.property``
+
 ### Drafts
 
 - ``Draft``

--- a/Sources/StructuredQueriesCore/PrimaryKeyed.swift
+++ b/Sources/StructuredQueriesCore/PrimaryKeyed.swift
@@ -86,6 +86,10 @@ extension PrimaryKeyedTable {
   ) -> Where<Self> {
     Self.where { $0.primaryKey.eq(primaryKey) }
   }
+
+  public var primaryKey: PrimaryKey.QueryOutput {
+    self[keyPath: Self.columns.primaryKey.keyPath]
+  }
 }
 
 extension TableDraft {


### PR DESCRIPTION
It can be helpful to be able to pluck off a primary key for a row more simply when dealing with primary keyed tables in the abstract.
