### PR TITLE
Apply default scope to `Table.{delete,update}()`

### DIFF
--- a/Sources/StructuredQueriesCore/Statements/Delete.swift
+++ b/Sources/StructuredQueriesCore/Statements/Delete.swift
@@ -8,7 +8,7 @@ extension Table {
   ///
   /// - Returns: A delete statement.
   public static func delete() -> DeleteOf<Self> {
-    Delete()
+    Where().delete()
   }
 }
 

--- a/Sources/StructuredQueriesCore/Statements/Update.swift
+++ b/Sources/StructuredQueriesCore/Statements/Update.swift
@@ -37,7 +37,7 @@ extension Table {
     or conflictResolution: ConflictResolution? = nil,
     set updates: (inout Updates<Self>) -> Void
   ) -> UpdateOf<Self> {
-    Update(conflictResolution: conflictResolution, updates: Updates(updates))
+    Where().update(or: conflictResolution, set: updates)
   }
 }
 

--- a/Tests/StructuredQueriesTests/TableTests.swift
+++ b/Tests/StructuredQueriesTests/TableTests.swift
@@ -129,6 +129,22 @@ extension SnapshotTests {
           └─────────────────────────────────────────────┘
           """
         }
+        assertQuery(
+          Row
+            .delete()
+            .where { $0.id > 0 }
+            .returning(\.self)
+        ) {
+          """
+          DELETE FROM "rows"
+          WHERE NOT ("rows"."isDeleted") AND ("rows"."id" > 0)
+          RETURNING "id", "isDeleted"
+          """
+        } results: {
+          """
+
+          """
+        }
 
         assertQuery(
           Row
@@ -157,8 +173,8 @@ extension SnapshotTests {
       @Test func update() throws {
         assertQuery(
           Row
-            .where { $0.id > 0 }
             .update { $0.isDeleted.toggle() }
+            .where { $0.id > 0 }
             .returning(\.self)
         ) {
           """
@@ -175,6 +191,23 @@ extension SnapshotTests {
           │   isDeleted: true                           │
           │ )                                           │
           └─────────────────────────────────────────────┘
+          """
+        }
+        assertQuery(
+          Row
+            .where { $0.id > 0 }
+            .update { $0.isDeleted.toggle() }
+            .returning(\.self)
+        ) {
+          """
+          UPDATE "rows"
+          SET "isDeleted" = NOT ("rows"."isDeleted")
+          WHERE NOT ("rows"."isDeleted") AND ("rows"."id" > 0)
+          RETURNING "id", "isDeleted"
+          """
+        } results: {
+          """
+
           """
         }
 
@@ -386,8 +419,8 @@ extension SnapshotTests {
       @Test func delete() throws {
         assertQuery(
           Row
-            .where { $0.id > 0 }
             .delete()
+            .where { $0.id > 0 }
             .returning(\.self)
         ) {
           """
@@ -403,6 +436,22 @@ extension SnapshotTests {
           │   isDeleted: false                         │
           │ )                                          │
           └────────────────────────────────────────────┘
+          """
+        }
+        assertQuery(
+          Row
+            .where { $0.id > 0 }
+            .delete()
+            .returning(\.self)
+        ) {
+          """
+          DELETE FROM "rows"
+          WHERE NOT ("rows"."isDeleted") AND ("rows"."id" > 0)
+          RETURNING "id", "isDeleted"
+          """
+        } results: {
+          """
+
           """
         }
 
@@ -433,8 +482,8 @@ extension SnapshotTests {
       @Test func update() throws {
         assertQuery(
           Row
-            .where { $0.id > 0 }
             .update { $0.isDeleted.toggle() }
+            .where { $0.id > 0 }
             .returning(\.self)
         ) {
           """
@@ -451,6 +500,23 @@ extension SnapshotTests {
           │   isDeleted: true                          │
           │ )                                          │
           └────────────────────────────────────────────┘
+          """
+        }
+        assertQuery(
+          Row
+            .where { $0.id > 0 }
+            .update { $0.isDeleted.toggle() }
+            .returning(\.self)
+        ) {
+          """
+          UPDATE "rows"
+          SET "isDeleted" = NOT ("rows"."isDeleted")
+          WHERE NOT ("rows"."isDeleted") AND ("rows"."id" > 0)
+          RETURNING "id", "isDeleted"
+          """
+        } results: {
+          """
+
           """
         }
 


### PR DESCRIPTION
This was only being applied when the `where` came first.