### PR TITLE
`Where.{and,or,not}()` fixes

### DIFF
--- a/Sources/StructuredQueriesCore/Statements/Where.swift
+++ b/Sources/StructuredQueriesCore/Statements/Where.swift
@@ -357,6 +357,8 @@ extension Where: SelectStatement {
   /// - Parameter other: Another where clause.
   /// - Returns: A where clause that `AND`s the given where clauses together.
   public func and(_ other: Self) -> Self {
+    guard !predicates.isEmpty else { return other }
+    guard !other.predicates.isEmpty else { return self }
     var `where` = self
     `where`.predicates = [
       """
@@ -373,6 +375,8 @@ extension Where: SelectStatement {
   /// - Parameter other: Another where clause.
   /// - Returns: A where clause that `OR`s the given where clauses together.
   public func or(_ other: Self) -> Self {
+    guard !predicates.isEmpty else { return other }
+    guard !other.predicates.isEmpty else { return self }
     var `where` = self
     `where`.predicates = [
       """
@@ -389,7 +393,9 @@ extension Where: SelectStatement {
   /// - Returns: A where clause that `NOT`s this where clause.
   public func not() -> Self {
     var `where` = self
-    `where`.predicates = ["NOT (\(`where`.predicates.joined(separator: " AND ")))"]
+    `where`.predicates = [
+      "NOT (\(predicates.isEmpty ? "1" : predicates.joined(separator: " AND ")))"
+    ]
     return `where`
   }
 

--- a/Tests/StructuredQueriesTests/WhereTests.swift
+++ b/Tests/StructuredQueriesTests/WhereTests.swift
@@ -40,6 +40,36 @@ extension SnapshotTests {
         └───┘
         """
       }
+      assertQuery(
+        Reminder.all.and(Reminder.where(\.isFlagged)).count()
+      ) {
+        """
+        SELECT count(*)
+        FROM "reminders"
+        WHERE "reminders"."isFlagged"
+        """
+      } results: {
+        """
+        ┌───┐
+        │ 2 │
+        └───┘
+        """
+      }
+      assertQuery(
+        Reminder.where(\.isFlagged).and(Reminder.all).count()
+      ) {
+        """
+        SELECT count(*)
+        FROM "reminders"
+        WHERE "reminders"."isFlagged"
+        """
+      } results: {
+        """
+        ┌───┐
+        │ 2 │
+        └───┘
+        """
+      }
     }
 
     @Test(.snapshots(record: .never)) func emptyResults() {
@@ -93,6 +123,36 @@ extension SnapshotTests {
         └───┘
         """
       }
+      assertQuery(
+        Reminder.all.or(Reminder.where(\.isFlagged)).count()
+      ) {
+        """
+        SELECT count(*)
+        FROM "reminders"
+        WHERE "reminders"."isFlagged"
+        """
+      }results: {
+        """
+        ┌───┐
+        │ 2 │
+        └───┘
+        """
+      }
+      assertQuery(
+        Reminder.where(\.isFlagged).or(Reminder.all).count()
+      ) {
+        """
+        SELECT count(*)
+        FROM "reminders"
+        WHERE "reminders"."isFlagged"
+        """
+      }results: {
+        """
+        ┌───┐
+        │ 2 │
+        └───┘
+        """
+      }
     }
 
     @Test func not() {
@@ -125,6 +185,21 @@ extension SnapshotTests {
         """
         ┌───┐
         │ 7 │
+        └───┘
+        """
+      }
+      assertQuery(
+        Reminder.all.not().count()
+      ) {
+        """
+        SELECT count(*)
+        FROM "reminders"
+        WHERE NOT (1)
+        """
+      } results: {
+        """
+        ┌───┐
+        │ 0 │
         └───┘
         """
       }


### PR DESCRIPTION
When called with a predicate-less `Where` it could lead to invalid SQL.