### PR TITLE
Handle single Join & Where on query helpers

### DIFF
--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -1143,37 +1143,6 @@ extension Select {
   /// Creates a new select statement from this one by appending a predicate to its `WHERE` clause.
   ///
   /// - Parameter predicate: A closure that produces a Boolean query expression from this select's
-  ///   tables with a single join.
-  /// - Returns: A new select statement that appends the given predicate to its `WHERE` clause.
-  public func `where`(
-    _ predicate: (From.TableColumns, Joins.TableColumns) -> some QueryExpression<
-      some _OptionalPromotable<Bool?>
-    >
-  ) -> Self
-  where Joins: Table {
-    var select = self
-    select.where.append(predicate(From.columns, Joins.columns).queryFragment)
-    return select
-  }
-
-  /// Creates a new select statement from this one by appending a predicate to its `WHERE` clause.
-  ///
-  /// - Parameter predicate: A result builder closure that returns a Boolean expression to filter
-  ///   by.
-  /// - Returns: A new select statement that appends the given predicate to its `WHERE` clause.
-  public func `where`(
-    @QueryFragmentBuilder<Bool>
-    _ predicate: (From.TableColumns, Joins.TableColumns) -> [QueryFragment]
-  ) -> Self
-  where Joins: Table {
-    var select = self
-    select.where.append(contentsOf: predicate(From.columns, Joins.columns))
-    return select
-  }
-
-  /// Creates a new select statement from this one by appending a predicate to its `WHERE` clause.
-  ///
-  /// - Parameter predicate: A closure that produces a Boolean query expression from this select's
   ///   tables.
   /// - Returns: A new select statement that appends the given predicate to its `WHERE` clause.
   @_disfavoredOverload
@@ -1200,6 +1169,38 @@ extension Select {
   where Joins == (repeat each J) {
     var select = self
     select.where.append(contentsOf: predicate(From.columns, repeat (each J).columns))
+    return select
+  }
+
+  /// Creates a new select statement from this one by appending a predicate to its `WHERE` clause.
+  ///
+  /// - Parameter predicate: A closure that produces a Boolean query expression from this select's
+  ///   tables.
+  /// - Returns: A new select statement that appends the given predicate to its `WHERE` clause.
+  @_disfavoredOverload
+  public func `where`(
+    _ predicate: (From.TableColumns, Joins.TableColumns) -> some QueryExpression<
+      some _OptionalPromotable<Bool?>
+    >
+  ) -> Self
+  where Joins: Table {
+    var select = self
+    select.where.append(predicate(From.columns, Joins.columns).queryFragment)
+    return select
+  }
+
+  /// Creates a new select statement from this one by appending a predicate to its `WHERE` clause.
+  ///
+  /// - Parameter predicate: A result builder closure that returns a Boolean expression to filter
+  ///   by.
+  /// - Returns: A new select statement that appends the given predicate to its `WHERE` clause.
+  public func `where`(
+    @QueryFragmentBuilder<Bool>
+    _ predicate: (From.TableColumns, Joins.TableColumns) -> [QueryFragment]
+  ) -> Self
+  where Joins: Table {
+    var select = self
+    select.where.append(contentsOf: predicate(From.columns, Joins.columns))
     return select
   }
 
@@ -1252,6 +1253,32 @@ extension Select {
     _group(by: grouping)
   }
 
+  /// Creates a new select statement from this one by appending the given column to its `GROUP BY`
+  /// clause.
+  ///
+  /// - Parameter grouping: A closure that returns a column to group by from this select's tables.
+  /// - Returns: A new select statement that groups by the given column.
+  public func group<C: QueryExpression>(
+    by grouping: (From.TableColumns, Joins.TableColumns) -> C
+  ) -> Self where Joins: Table {
+    _group(by: grouping)
+  }
+
+  /// Creates a new select statement from this one by appending the given columns to its `GROUP BY`
+  /// clause.
+  ///
+  /// - Parameter grouping: A closure that returns a column to group by from this select's tables.
+  /// - Returns: A new select statement that groups by the given column.
+  public func group<
+    C1: QueryExpression,
+    C2: QueryExpression,
+    each C3: QueryExpression
+  >(
+    by grouping: (From.TableColumns, Joins.TableColumns) -> (C1, C2, repeat each C3)
+  ) -> Self where Joins: Table {
+    _group(by: grouping)
+  }
+
   private func _group<
     each C: QueryExpression,
     each J: Table
@@ -1262,6 +1289,17 @@ extension Select {
     select.group
       .append(
         contentsOf: Array(repeat each grouping(From.columns, repeat (each J).columns))
+      )
+    return select
+  }
+
+  private func _group<each C: QueryExpression>(
+    by grouping: (From.TableColumns, Joins.TableColumns) -> (repeat each C)
+  ) -> Self where Joins: Table {
+    var select = self
+    select.group
+      .append(
+        contentsOf: Array(repeat each grouping(From.columns, Joins.columns))
       )
     return select
   }
@@ -1298,6 +1336,38 @@ extension Select {
     return select
   }
 
+  /// Creates a new select statement from this one by appending a predicate to its `HAVING` clause.
+  ///
+  /// - Parameter predicate: A closure that produces a Boolean query expression from this select's
+  ///   tables.
+  /// - Returns: A new select statement that appends the given predicate to its `HAVING` clause.
+  @_disfavoredOverload
+  public func having(
+    _ predicate: (From.TableColumns, Joins.TableColumns) -> some QueryExpression<
+      some _OptionalPromotable<Bool?>
+    >
+  ) -> Self
+  where Joins: Table {
+    var select = self
+    select.having.append(predicate(From.columns, Joins.columns).queryFragment)
+    return select
+  }
+
+  /// Creates a new select statement from this one by appending a predicate to its `HAVING` clause.
+  ///
+  /// - Parameter predicate: A result builder closure that returns a Boolean expression to filter
+  ///   by.
+  /// - Returns: A new select statement that appends the given predicate to its `HAVING` clause.
+  public func having(
+    @QueryFragmentBuilder<Bool>
+    _ predicate: (From.TableColumns, Joins.TableColumns) -> [QueryFragment]
+  ) -> Self
+  where Joins: Table {
+    var select = self
+    select.having.append(contentsOf: predicate(From.columns, Joins.columns))
+    return select
+  }
+
   /// Creates a new select statement from this one by appending a column to its `ORDER BY` clause.
   ///
   /// - Parameter ordering: A key path to a column to order by.
@@ -1322,6 +1392,20 @@ extension Select {
     return select
   }
 
+  /// Creates a new select statement from this one by appending columns to its `ORDER BY` clause.
+  ///
+  /// - Parameter ordering: A result builder closure that returns columns to order by.
+  /// - Returns: A new select statement that appends the returned columns to its `ORDER BY` clause.
+  public func order(
+    @QueryFragmentBuilder<()>
+    by ordering: (From.TableColumns, Joins.TableColumns) -> [QueryFragment]
+  ) -> Self
+  where Joins: Table {
+    var select = self
+    select.order.append(contentsOf: ordering(From.columns, Joins.columns))
+    return select
+  }
+
   /// Creates a new select statement from this one by overriding its `LIMIT` and `OFFSET` clauses.
   ///
   /// - Parameters:
@@ -1330,13 +1414,32 @@ extension Select {
   /// - Returns: A new select statement that overrides this one's `LIMIT` and `OFFSET` clauses.
   public func limit<each J: Table>(
     _ maxLength: (From.TableColumns, repeat (each J).TableColumns) -> some QueryExpression<Int>,
-    offset: ((From.TableColumns, repeat (each J).TableColumns) -> some QueryExpression<Int>)? = nil
+    offset: ((From.TableColumns, repeat (each J).TableColumns) -> any QueryExpression<Int>)? = nil
   ) -> Self
   where Joins == (repeat each J) {
     var select = self
     select.limit = _LimitClause(
       maxLength: maxLength(From.columns, repeat (each J).columns).queryFragment,
       offset: offset?(From.columns, repeat (each J).columns).queryFragment ?? select.limit?.offset
+    )
+    return select
+  }
+
+  /// Creates a new select statement from this one by overriding its `LIMIT` and `OFFSET` clauses.
+  ///
+  /// - Parameters:
+  ///   - maxLength: A closure that produces a `LIMIT` expression from this select's tables.
+  ///   - offset: A closure that produces an `OFFSET` expression from this select's tables.
+  /// - Returns: A new select statement that overrides this one's `LIMIT` and `OFFSET` clauses.
+  public func limit(
+    _ maxLength: (From.TableColumns, Joins.TableColumns) -> some QueryExpression<Int>,
+    offset: ((From.TableColumns, Joins.TableColumns) -> any QueryExpression<Int>)? = nil
+  ) -> Self
+  where Joins: Table {
+    var select = self
+    select.limit = _LimitClause(
+      maxLength: maxLength(From.columns, Joins.columns).queryFragment,
+      offset: offset?(From.columns, Joins.columns).queryFragment ?? select.limit?.offset
     )
     return select
   }
@@ -1381,6 +1484,32 @@ extension Select {
   where Columns == (repeat each C), Joins == (repeat each J) {
     let filter = filter?(From.columns, repeat (each J).columns)
     return select { _ in .count(filter: filter) }
+  }
+
+  /// Creates a new select statement from this one by appending `count(*)` to its selection.
+  ///
+  /// - Parameter filter: A `FILTER` clause to apply to the aggregation.
+  /// - Returns: A new select statement that selects `count(*)`.
+  public func count(
+    filter: ((From.TableColumns, Joins.TableColumns) -> any QueryExpression<Bool>)? = nil
+  ) -> Select<Int, From, Joins>
+  where Columns == (), Joins: Table {
+    let filter = filter?(From.columns, Joins.columns)
+    return select { _, _ in .count(filter: filter) }
+  }
+
+  /// Creates a new select statement from this one by appending `count(*)` to its selection.
+  ///
+  /// - Parameter filter: A `FILTER` clause to apply to the aggregation.
+  /// - Returns: A new select statement that selects `count(*)`.
+  public func count<each C: QueryRepresentable>(
+    filter: ((From.TableColumns, Joins.TableColumns) -> any QueryExpression<Bool>)? = nil
+  ) -> Select<
+    (repeat each C, Int), From, Joins
+  >
+  where Columns == (repeat each C), Joins: Table {
+    let filter = filter?(From.columns, Joins.columns)
+    return select { _, _ in .count(filter: filter) }
   }
 
   /// Creates a new select statement from this one by transforming its selected columns to a new

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -1402,6 +1402,20 @@ extension SnapshotTests {
         }
       }
     }
+
+    @Test func singleJoinChaining() {
+      let base = Reminder.group(by: \.id).join(ReminderTag.all) { $0.id.eq($1.reminderID) }
+      _ = base.select { r, _ in r.isCompleted }
+      _ = base.where { r, _ in r.isCompleted }
+      _ = base.group { r, _ in r.isCompleted }
+      _ = base.having { r, _ in r.isCompleted }
+      _ = base.order { r, _ in r.isCompleted }
+      _ = base.limit { r, _ in r.title.length() }
+      _ = base.limit(1)
+      _ = base.count()
+      _ = base.count { r, _ in r.isCompleted }
+      _ = base.map {}
+    }
   }
 }
 


### PR DESCRIPTION
I'm facing the same issue described at 
https://github.com/pointfreeco/sharing-grdb/discussions/107

When you join two tables, it becomes a tuple (TableA, SomeOtherTable)
The where method expects the Joins to be a parameter pack (repeat each J)

When you join one table, it return single Table type (not a tuple or empty)?


(Sorry. Not so familiar with Swift. Maybe some better way to handle it)
