### PR TITLE
Remove `#sql` literal requirement

### DIFF
--- a/Sources/StructuredQueriesCore/QueryFragment.swift
+++ b/Sources/StructuredQueriesCore/QueryFragment.swift
@@ -3,6 +3,9 @@
 /// You will typically create instances of this type using string literals, where bindings are
 /// directly interpolated into the string. This most commonly occurs when using the `#sql` macro,
 /// which takes values of this type.
+///
+/// > Tip: The `#sql` macro performs basic linting and validation of a SQL string literal. Prefer it
+/// > for creating `QueryFragment`s where possible.
 public struct QueryFragment: Hashable, Sendable {
   /// A segment of a query fragment.
   public enum Segment: Hashable, Sendable {

--- a/Sources/StructuredQueriesMacros/SQLMacro.swift
+++ b/Sources/StructuredQueriesMacros/SQLMacro.swift
@@ -195,17 +195,6 @@ public enum SQLMacro: ExpressionMacro {
           )
         )
       }
-    } else {
-      context.diagnose(
-        Diagnostic(
-          node: argument,
-          message: MacroExpansionErrorMessage(
-            """
-            '#sql' requires a query literal.
-            """
-          )
-        )
-      )
     }
     return "\(moduleName).SQLQueryExpression(\(argument))"
   }

--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -570,6 +570,7 @@ extension TableMacro: ExtensionMacro {
     var letSchemaName: DeclSyntax?
     if let schemaName {
       letSchemaName = """
+
         public static let schemaName: Swift.String? = \(schemaName)
         """
     }
@@ -1038,7 +1039,7 @@ extension TableMacro: MemberMacro {
       [\(writableColumns.map { "QueryValue.columns.\($0)" as ExprSyntax }, separator: ", ")]
       }
       public var queryFragment: QueryFragment {
-      "\(selectedColumns.map { #"\(self.\#($0))"# as ExprSyntax }, separator: ", ")"
+      "\(raw: selectedColumns.map { #"\(self.\#($0))"# }.joined(separator: ", "))"
       }
       }
       """,


### PR DESCRIPTION
It's overly restrictive. While passing a query fragment directly is equivalent to `SQLQueryExpression(fragment)`, it doesn't seem worth a hard error.

Alternately we could make it a warning with a fix-it that swaps `#sql` for `SQLQueryExpression`, but not sure it's worth the distinction?