### PR TITLE
Add `TableDefinition` dynamic subscript for better compiler errors

### DIFF
--- a/Sources/StructuredQueriesCore/TableDefinition.swift
+++ b/Sources/StructuredQueriesCore/TableDefinition.swift
@@ -20,6 +20,7 @@ extension TableDefinition {
   //
   // > Referencing subscript 'subscript(dynamicMember:)' on 'TableDefinition' requires that 'T'
   // > conform to 'TableDraft'
+  @_disfavoredOverload
   public subscript<Member>(
     dynamicMember keyPath: KeyPath<Self, Member>
   ) -> Member {


### PR DESCRIPTION
Without it, a typo (like `$0.parentId` vs `$0.parentID`) produces a bad error message for non-primary-keyed tables:

> Referencing subscript 'subscript(dynamicMember:)' on 'TableDefinition' requires that 'T' conform to 'TableDraft'

With it:

> Value of type 'T.TableColumns' has no dynamic member 'parentId' using key path from root type 'T.TableColumns'