### PR TITLE
Add `buildArray` support for `QueryFragmentBuilder<Bool>`

### DIFF
--- a/Sources/StructuredQueriesCore/QueryFragmentBuilder.swift
+++ b/Sources/StructuredQueriesCore/QueryFragmentBuilder.swift
@@ -22,6 +22,10 @@ public enum QueryFragmentBuilder<Clause> {
 }
 
 extension QueryFragmentBuilder<Bool> {
+  public static func buildArray(_ components: [[QueryFragment]]) -> [QueryFragment] {
+    components.map { $0.joined(separator: " AND ") }
+  }
+
   public static func buildExpression(
     _ expression: some QueryExpression<Bool>
   ) -> [QueryFragment] {

--- a/Tests/StructuredQueriesTests/WhereTests.swift
+++ b/Tests/StructuredQueriesTests/WhereTests.swift
@@ -233,5 +233,22 @@ extension SnapshotTests {
         """
       }
     }
+
+    @Test func buildArray() {
+      let terms = ["daily", "monthly"]
+      assertQuery(
+        RemindersList.where {
+          for term in terms {
+            $0.title.contains(term)
+          }
+        }
+      ) {
+        """
+        SELECT "remindersLists"."id", "remindersLists"."color", "remindersLists"."title", "remindersLists"."position"
+        FROM "remindersLists"
+        WHERE ("remindersLists"."title" LIKE '%daily%') AND ("remindersLists"."title" LIKE '%monthly%')
+        """
+      }
+    }
   }
 }


### PR DESCRIPTION
Support for more dynamic queries based off arrays:

```swift
Reminder.where {
  for searchTerm in searchTerms {
    $0.title.contains(searchTerm) || $0.notes.contains(searchTerm)
  }
}
```