### PR TITLE
Make trigger types sendable.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "798c8512a776b32d09302f38d1441266cd2b60777300aa1d86c89fa56f1e5fea",
+  "originHash" : "b5899dec35ccc82d161bdd4fd1114afbc74a459e1a742760fd9c65bc0582a716",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -89,6 +89,15 @@
       "state" : {
         "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
         "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "swift-tagged",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-tagged",
+      "state" : {
+        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
+        "version" : "0.10.0"
       }
     },
     {

--- a/Sources/StructuredQueriesCore/Triggers.swift
+++ b/Sources/StructuredQueriesCore/Triggers.swift
@@ -238,7 +238,7 @@ extension Table {
 /// functions.
 ///
 /// To learn more, see <doc:Triggers>.
-public struct TemporaryTrigger<On: Table>: Statement {
+public struct TemporaryTrigger<On: Table>: Sendable, Statement {
   public typealias From = Never
   public typealias Joins = ()
   public typealias QueryValue = ()
@@ -251,7 +251,7 @@ public struct TemporaryTrigger<On: Table>: Statement {
   /// The database event used in a trigger.
   ///
   /// To learn more, see <doc:Triggers>.
-  public struct Operation: QueryExpression {
+  public struct Operation: Sendable, QueryExpression {
     public typealias QueryValue = ()
 
     public enum _Old: AliasName { public static var aliasName: String { "old" } }


### PR DESCRIPTION
These concrete types are trivially sendable and allow us to do `static let` triggers instead of `static var`.