### PR TITLE
Add `SecondsRepresentation` for Foundation `Duration` type. 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "798c8512a776b32d09302f38d1441266cd2b60777300aa1d86c89fa56f1e5fea",
+  "originHash" : "b5899dec35ccc82d161bdd4fd1114afbc74a459e1a742760fd9c65bc0582a716",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -89,6 +89,15 @@
       "state" : {
         "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
         "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "swift-tagged",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-tagged",
+      "state" : {
+        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
+        "version" : "0.10.0"
       }
     },
     {

--- a/Sources/StructuredQueriesCore/QueryBindable+Foundation.swift
+++ b/Sources/StructuredQueriesCore/QueryBindable+Foundation.swift
@@ -23,4 +23,59 @@ extension URL: QueryBindable {
   }
 }
 
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, visionOS 1, *)
+extension Duration {
+  /// A representation of a Swift `Duration` at the precision of seconds.
+  ///
+  /// Any sub-second durations will be rounded down to the nearest second. 
+  ///
+  /// ## Usage
+  /// ```swift
+  /// @Table
+  /// struct Event {
+  ///   @Column(as: Duration.SecondsRepresentation.self)
+  ///   var duration: Duration
+  /// }
+  /// ```
+  public struct SecondsRepresentation: QueryRepresentable {
+    public var queryOutput: Duration
+    
+    public var seconds: Int64 {
+      queryOutput.components.seconds
+    }
+    
+    public init(queryOutput: Duration) {
+      self.queryOutput = queryOutput
+    }
+    
+    public init(seconds: Int64) throws {
+      self.queryOutput = Duration(secondsComponent: seconds, attosecondsComponent: 0)
+    }
+  }
+}
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, visionOS 1, *)
+extension Duration.SecondsRepresentation: QueryBindable {
+  public var queryBinding: QueryBinding {
+    .int(queryOutput.components.seconds)
+  }
+}
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, visionOS 1, *)
+extension Duration.SecondsRepresentation: QueryDecodable {
+  public init(decoder: inout some QueryDecoder) throws {
+    try self.init(queryOutput: Duration(
+      secondsComponent: Int64(decoder: &decoder),
+      attosecondsComponent: 0
+    ))
+  }
+}
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, visionOS 1, *)
+extension Duration.SecondsRepresentation: SQLiteType {
+  public static var typeAffinity: SQLiteTypeAffinity {
+    Int64.typeAffinity
+  }
+}
+
 private struct InvalidURL: Error {}

--- a/Tests/StructuredQueriesTests/DecodingTests.swift
+++ b/Tests/StructuredQueriesTests/DecodingTests.swift
@@ -129,6 +129,12 @@ extension SnapshotTests {
             )
           )
       )
+      #expect(
+        try db.execute(
+          SimpleSelect { #sql("1234567890", as: Duration.SecondsRepresentation.self) }
+        )
+        .first == Duration(secondsComponent: 1234567890, attosecondsComponent: 0)
+      )
     }
 
     @Test func optionalDate() throws {


### PR DESCRIPTION
This PR adds a new type `Duration.SecondsRepresentation` conforming to `QueryBindable`. This encodes and decodes a Swift `Duration` to/from SQL at seconds level precision. Any sub-second durations will be rounded down to the nearest second. 