### PR TITLE
Add join overloads for `Joins: Table`

### DIFF
--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -719,7 +719,25 @@ extension Select {
       (From.TableColumns, Joins.TableColumns, F.TableColumns)
     ) -> some QueryExpression<Bool>
   ) -> Select<(), From, (Joins, F)> where Joins: Table {
-    fatalError()
+    let other = other.asSelect()
+    let join = _JoinClause(
+      operator: .inner,
+      table: F.self,
+      constraint: constraint(
+        (From.columns, Joins.columns, F.columns)
+      )
+    )
+    return Select<(), From, (Joins, F)>(
+      isEmpty: isEmpty || other.isEmpty,
+      distinct: distinct || other.distinct,
+      columns: columns + other.columns,
+      joins: joins + [join] + other.joins,
+      where: `where` + other.where,
+      group: group + other.group,
+      having: having + other.having,
+      order: order + other.order,
+      limit: other.limit ?? limit
+    )
   }
 
   /// Creates a new select statement from this one by left-joining another table.

--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -1064,7 +1064,7 @@ extension Select {
       operator: .right,
       table: F.self,
       constraint: constraint(
-        (From.columns, Joins.columns, F.columns,)
+        (From.columns, Joins.columns, F.columns)
       )
     )
     return Select<(), From._Optionalized, (Joins._Optionalized, F)>(

--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -710,6 +710,18 @@ extension Select {
     )
   }
 
+  @_disfavoredOverload
+  @_documentation(visibility: private)
+  public func join<F: Table>(
+    // TODO: Report issue to Swift team. Using 'some' crashes the compiler.
+    _ other: any SelectStatementOf<F>,
+    on constraint: (
+      (From.TableColumns, Joins.TableColumns, F.TableColumns)
+    ) -> some QueryExpression<Bool>
+  ) -> Select<(), From, (Joins, F)> where Joins: Table {
+    fatalError()
+  }
+
   /// Creates a new select statement from this one by left-joining another table.
   ///
   /// - Parameters:
@@ -837,6 +849,37 @@ extension Select {
       )
     )
     return Select<QueryValue, From, (F._Optionalized, repeat (each J)._Optionalized)>(
+      isEmpty: isEmpty || other.isEmpty,
+      distinct: distinct || other.distinct,
+      columns: columns + other.columns,
+      joins: joins + [join] + other.joins,
+      where: `where` + other.where,
+      group: group + other.group,
+      having: having + other.having,
+      order: order + other.order,
+      limit: other.limit ?? limit
+    )
+  }
+
+  @_disfavoredOverload
+  @_documentation(visibility: private)
+  public func leftJoin<F: Table>(
+    // TODO: Report issue to Swift team. Using 'some' crashes the compiler.
+    _ other: any SelectStatementOf<F>,
+    on constraint: (
+      (From.TableColumns, Joins.TableColumns, F.TableColumns)
+    ) -> some QueryExpression<Bool>
+  ) -> Select<(), From, (Joins, F._Optionalized)>
+  where Joins: Table {
+    let other = other.asSelect()
+    let join = _JoinClause(
+      operator: .left,
+      table: F.self,
+      constraint: constraint(
+        (From.columns, Joins.columns, F.columns)
+      )
+    )
+    return Select<(), From, (Joins, F._Optionalized)>(
       isEmpty: isEmpty || other.isEmpty,
       distinct: distinct || other.distinct,
       columns: columns + other.columns,
@@ -988,6 +1031,37 @@ extension Select {
     )
   }
 
+  @_disfavoredOverload
+  @_documentation(visibility: private)
+  public func rightJoin<F: Table>(
+    // TODO: Report issue to Swift team. Using 'some' crashes the compiler.
+    _ other: any SelectStatementOf<F>,
+    on constraint: (
+      (From.TableColumns, Joins.TableColumns, F.TableColumns)
+    ) -> some QueryExpression<Bool>
+  ) -> Select<(), From._Optionalized, (Joins._Optionalized, F)>
+  where Joins: Table {
+    let other = other.asSelect()
+    let join = _JoinClause(
+      operator: .right,
+      table: F.self,
+      constraint: constraint(
+        (From.columns, Joins.columns, F.columns,)
+      )
+    )
+    return Select<(), From._Optionalized, (Joins._Optionalized, F)>(
+      isEmpty: isEmpty || other.isEmpty,
+      distinct: distinct || other.distinct,
+      columns: columns + other.columns,
+      joins: joins + [join] + other.joins,
+      where: `where` + other.where,
+      group: group + other.group,
+      having: having + other.having,
+      order: order + other.order,
+      limit: other.limit ?? limit
+    )
+  }
+
   /// Creates a new select statement from this one by full-joining another table.
   ///
   /// - Parameters:
@@ -1115,6 +1189,37 @@ extension Select {
       )
     )
     return Select<QueryValue, From._Optionalized, (F._Optionalized, repeat (each J)._Optionalized)>(
+      isEmpty: isEmpty || other.isEmpty,
+      distinct: distinct || other.distinct,
+      columns: columns + other.columns,
+      joins: joins + [join] + other.joins,
+      where: `where` + other.where,
+      group: group + other.group,
+      having: having + other.having,
+      order: order + other.order,
+      limit: other.limit ?? limit
+    )
+  }
+
+  @_disfavoredOverload
+  @_documentation(visibility: private)
+  public func fullJoin<F: Table>(
+    // TODO: Report issue to Swift team. Using 'some' crashes the compiler.
+    _ other: any SelectStatementOf<F>,
+    on constraint: (
+      (From.TableColumns, Joins.TableColumns, F.TableColumns)
+    ) -> some QueryExpression<Bool>
+  ) -> Select<(), From._Optionalized, (Joins._Optionalized, F._Optionalized)>
+  where Joins: Table {
+    let other = other.asSelect()
+    let join = _JoinClause(
+      operator: .full,
+      table: F.self,
+      constraint: constraint(
+        (From.columns, Joins.columns, F.columns)
+      )
+    )
+    return Select<(), From._Optionalized, (Joins._Optionalized, F._Optionalized)>(
       isEmpty: isEmpty || other.isEmpty,
       distinct: distinct || other.distinct,
       columns: columns + other.columns,

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -1406,6 +1406,22 @@ extension SnapshotTests {
     @Test func singleJoinChaining() {
       let base = Reminder.group(by: \.id).join(ReminderTag.all) { $0.id.eq($1.reminderID) }
       _ = base.select { r, _ in r.isCompleted }
+      _ = base.join(RemindersList.all) { _, _, _ in true }
+      _ = base.leftJoin(RemindersList.all) { _, _, _ in true }
+      _ = base.rightJoin(RemindersList.all) { _, _, _ in true }
+      _ = base.fullJoin(RemindersList.all) { _, _, _ in true }
+      _ = base
+        .join(RemindersList.all) { _, _, _ in true }
+        .join(RemindersList.all) { _, _, _, _ in true }
+      _ = base
+        .leftJoin(RemindersList.all) { _, _, _ in true }
+        .leftJoin(RemindersList.all) { _, _, _, _ in true }
+      _ = base
+        .rightJoin(RemindersList.all) { _, _, _ in true }
+        .rightJoin(RemindersList.all) { _, _, _, _ in true }
+      _ = base
+        .fullJoin(RemindersList.all) { _, _, _ in true }
+        .fullJoin(RemindersList.all) { _, _, _, _ in true }
       _ = base.where { r, _ in r.isCompleted }
       _ = base.group { r, _ in r.isCompleted }
       _ = base.having { r, _ in r.isCompleted }


### PR DESCRIPTION
Parameter packs break down when a pack generic is a single value (instead of a tuple) and has a conformance constraint. These overloads are to work around it.

Before 1.0 we should probably come up with a reasonable limitation of how joins work. Some ideas to reduce the overloads:

  - Joins require no selected columns on either side. While it'd be nice to splat them, it just doesn't work well with parameter packs today.

  - Joins require no joined tables on the righthand side. Again: it'd be nice to support this, but it doesn't work well in the language today.

This maybe even means joins take `Table.Type` instead of `Select<Table>`.

I think if these two limitations were known and documented we could eliminate the many of the overloads we've defined today.