### PR TITLE
Add datetime customization to createTemporaryTrigger

### DIFF
--- a/Sources/StructuredQueriesCore/Triggers.swift
+++ b/Sources/StructuredQueriesCore/Triggers.swift
@@ -128,8 +128,8 @@ extension Table {
   ///     operation, and source location.
   ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE TRIGGER` statement.
   ///   - dateColumn: A key path to a datetime column.
-  ///   - dateFunction: A database function that returns the current date, _e.g._,
-  ///     `#sql("date('subsec'))"`.
+  ///   - dateFunction: A database function that returns the current datetime, _e.g._,
+  ///     `#sql("datetime('subsec'))"`.
   ///   - expression: The expression used to generate the datetime.
   ///   - fileID: The source `#fileID` associated with the trigger.
   ///   - line: The source `#line` associated with the trigger.
@@ -139,7 +139,7 @@ extension Table {
     _ name: String? = nil,
     ifNotExists: Bool = false,
     afterUpdateTouch dateColumn: KeyPath<TableColumns, TableColumn<Self, D>>,
-    date dateFunction: any QueryExpression<D> = SQLQueryExpression<D>("date('subsec')"),
+    date dateFunction: any QueryExpression<D> = SQLQueryExpression<D>("datetime('subsec')"),
     fileID: StaticString = #fileID,
     line: UInt = #line,
     column: UInt = #column
@@ -210,8 +210,8 @@ extension Table {
   ///     operation, and source location.
   ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE TRIGGER` statement.
   ///   - dateColumn: A key path to a datetime column.
-  ///   - dateFunction: A database function that returns the current date, _e.g._,
-  ///     `#sql("date('subsec'))"`.
+  ///   - dateFunction: A database function that returns the current datetime, _e.g._,
+  ///     `#sql("datetime('subsec'))"`.
   ///   - fileID: The source `#fileID` associated with the trigger.
   ///   - line: The source `#line` associated with the trigger.
   ///   - column: The source `#column` associated with the trigger.
@@ -220,7 +220,7 @@ extension Table {
     _ name: String? = nil,
     ifNotExists: Bool = false,
     afterInsertTouch dateColumn: KeyPath<TableColumns, TableColumn<Self, D>>,
-    date dateFunction: any QueryExpression<D> = SQLQueryExpression<D>("date('subsec')"),
+    date dateFunction: any QueryExpression<D> = SQLQueryExpression<D>("datetime('subsec')"),
     fileID: StaticString = #fileID,
     line: UInt = #line,
     column: UInt = #column

--- a/Sources/StructuredQueriesCore/Triggers.swift
+++ b/Sources/StructuredQueriesCore/Triggers.swift
@@ -128,8 +128,8 @@ extension Table {
   ///     operation, and source location.
   ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE TRIGGER` statement.
   ///   - dateColumn: A key path to a datetime column.
-  ///   - dateFunction: A database function that returns the current date. Include parentheses in
-  ///     string, i.e. `"customDate()"`.
+  ///   - dateFunction: A database function that returns the current date, _e.g._,
+  ///     `#sql("date('subsec'))"`.
   ///   - expression: The expression used to generate the datetime.
   ///   - fileID: The source `#fileID` associated with the trigger.
   ///   - line: The source `#line` associated with the trigger.
@@ -139,7 +139,7 @@ extension Table {
     _ name: String? = nil,
     ifNotExists: Bool = false,
     afterUpdateTouch dateColumn: KeyPath<TableColumns, TableColumn<Self, D>>,
-    date dateFunction: StaticString = "datetime('subsec')",
+    date dateFunction: any QueryExpression<D> = SQLQueryExpression<D>("date('subsec')"),
     fileID: StaticString = #fileID,
     line: UInt = #line,
     column: UInt = #column
@@ -148,7 +148,7 @@ extension Table {
       name,
       ifNotExists: ifNotExists,
       afterUpdateTouch: {
-        $0[dynamicMember: dateColumn] = SQLQueryExpression("\(raw: dateFunction.description)")
+        $0[dynamicMember: dateColumn] = dateFunction
       },
       fileID: fileID,
       line: line,
@@ -210,8 +210,8 @@ extension Table {
   ///     operation, and source location.
   ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE TRIGGER` statement.
   ///   - dateColumn: A key path to a datetime column.
-  ///   - dateFunction: A database function that returns the current date. Include parentheses in
-  ///     string, i.e. `"customDate()"`.
+  ///   - dateFunction: A database function that returns the current date, _e.g._,
+  ///     `#sql("date('subsec'))"`.
   ///   - fileID: The source `#fileID` associated with the trigger.
   ///   - line: The source `#line` associated with the trigger.
   ///   - column: The source `#column` associated with the trigger.
@@ -220,7 +220,7 @@ extension Table {
     _ name: String? = nil,
     ifNotExists: Bool = false,
     afterInsertTouch dateColumn: KeyPath<TableColumns, TableColumn<Self, D>>,
-    date dateFunction: StaticString = "datetime('subsec')",
+    date dateFunction: any QueryExpression<D> = SQLQueryExpression<D>("date('subsec')"),
     fileID: StaticString = #fileID,
     line: UInt = #line,
     column: UInt = #column
@@ -229,7 +229,7 @@ extension Table {
       name,
       ifNotExists: ifNotExists,
       afterInsertTouch: {
-        $0[dynamicMember: dateColumn] = SQLQueryExpression("\(raw: dateFunction.description)")
+        $0[dynamicMember: dateColumn] = dateFunction
       },
       fileID: fileID,
       line: line,

--- a/Sources/StructuredQueriesCore/Triggers.swift
+++ b/Sources/StructuredQueriesCore/Triggers.swift
@@ -128,6 +128,7 @@ extension Table {
   ///     operation, and source location.
   ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE TRIGGER` statement.
   ///   - date: A key path to a datetime column.
+  ///   - expression: The expression used to generate the datetime.
   ///   - fileID: The source `#fileID` associated with the trigger.
   ///   - line: The source `#line` associated with the trigger.
   ///   - column: The source `#column` associated with the trigger.
@@ -136,6 +137,7 @@ extension Table {
     _ name: String? = nil,
     ifNotExists: Bool = false,
     afterUpdateTouch date: KeyPath<TableColumns, TableColumn<Self, D>>,
+    expression: String = "datetime('subsec')",
     fileID: StaticString = #fileID,
     line: UInt = #line,
     column: UInt = #column
@@ -144,7 +146,7 @@ extension Table {
       name,
       ifNotExists: ifNotExists,
       afterUpdateTouch: {
-        $0[dynamicMember: date] = SQLQueryExpression("datetime('subsec')")
+        $0[dynamicMember: date] = SQLQueryExpression("\(raw: expression)")
       },
       fileID: fileID,
       line: line,

--- a/Sources/StructuredQueriesCore/Triggers.swift
+++ b/Sources/StructuredQueriesCore/Triggers.swift
@@ -127,7 +127,9 @@ extension Table {
   ///   - name: The trigger's name. By default a unique name is generated depending using the table,
   ///     operation, and source location.
   ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE TRIGGER` statement.
-  ///   - date: A key path to a datetime column.
+  ///   - dateColumn: A key path to a datetime column.
+  ///   - dateFunction: A database function that returns the current date. Include parentheses in
+  ///     string, i.e. `"customDate()"`.
   ///   - expression: The expression used to generate the datetime.
   ///   - fileID: The source `#fileID` associated with the trigger.
   ///   - line: The source `#line` associated with the trigger.
@@ -136,8 +138,8 @@ extension Table {
   public static func createTemporaryTrigger<D: _OptionalPromotable<Date?>>(
     _ name: String? = nil,
     ifNotExists: Bool = false,
-    afterUpdateTouch date: KeyPath<TableColumns, TableColumn<Self, D>>,
-    expression: String = "datetime('subsec')",
+    afterUpdateTouch dateColumn: KeyPath<TableColumns, TableColumn<Self, D>>,
+    date dateFunction: StaticString = "datetime('subsec')",
     fileID: StaticString = #fileID,
     line: UInt = #line,
     column: UInt = #column
@@ -146,7 +148,7 @@ extension Table {
       name,
       ifNotExists: ifNotExists,
       afterUpdateTouch: {
-        $0[dynamicMember: date] = SQLQueryExpression("\(raw: expression)")
+        $0[dynamicMember: dateColumn] = SQLQueryExpression("\(raw: dateFunction.description)")
       },
       fileID: fileID,
       line: line,
@@ -207,7 +209,9 @@ extension Table {
   ///   - name: The trigger's name. By default a unique name is generated depending using the table,
   ///     operation, and source location.
   ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE TRIGGER` statement.
-  ///   - date: A key path to a datetime column.
+  ///   - dateColumn: A key path to a datetime column.
+  ///   - dateFunction: A database function that returns the current date. Include parentheses in
+  ///     string, i.e. `"customDate()"`.
   ///   - fileID: The source `#fileID` associated with the trigger.
   ///   - line: The source `#line` associated with the trigger.
   ///   - column: The source `#column` associated with the trigger.
@@ -215,7 +219,8 @@ extension Table {
   public static func createTemporaryTrigger<D: _OptionalPromotable<Date?>>(
     _ name: String? = nil,
     ifNotExists: Bool = false,
-    afterInsertTouch date: KeyPath<TableColumns, TableColumn<Self, D>>,
+    afterInsertTouch dateColumn: KeyPath<TableColumns, TableColumn<Self, D>>,
+    date dateFunction: StaticString = "datetime('subsec')",
     fileID: StaticString = #fileID,
     line: UInt = #line,
     column: UInt = #column
@@ -224,7 +229,7 @@ extension Table {
       name,
       ifNotExists: ifNotExists,
       afterInsertTouch: {
-        $0[dynamicMember: date] = SQLQueryExpression("datetime('subsec')")
+        $0[dynamicMember: dateColumn] = SQLQueryExpression("\(raw: dateFunction.description)")
       },
       fileID: fileID,
       line: line,

--- a/Tests/StructuredQueriesTests/TriggersTests.swift
+++ b/Tests/StructuredQueriesTests/TriggersTests.swift
@@ -115,6 +115,23 @@ extension SnapshotTests {
       }
     }
 
+    @Test func afterUpdateTouchCustomDate() {
+      assertQuery(
+        Reminder.createTemporaryTrigger(afterUpdateTouch: \.updatedAt, expression: "customDate()")
+      ) {
+        """
+        CREATE TEMPORARY TRIGGER
+          "after_update_on_reminders@StructuredQueriesTests/TriggersTests.swift:120:40"
+        AFTER UPDATE ON "reminders"
+        FOR EACH ROW BEGIN
+          UPDATE "reminders"
+          SET "updatedAt" = customDate()
+          WHERE ("reminders"."rowid" = "new"."rowid");
+        END
+        """
+      }
+    }
+
     @Test func multiStatement() {
       let trigger = RemindersList.createTemporaryTrigger(
         after: .insert { new in
@@ -133,7 +150,7 @@ extension SnapshotTests {
       assertQuery(trigger) {
         """
         CREATE TEMPORARY TRIGGER
-          "after_insert_on_remindersLists@StructuredQueriesTests/TriggersTests.swift:119:57"
+          "after_insert_on_remindersLists@StructuredQueriesTests/TriggersTests.swift:136:57"
         AFTER INSERT ON "remindersLists"
         FOR EACH ROW BEGIN
           UPDATE "remindersLists"

--- a/Tests/StructuredQueriesTests/TriggersTests.swift
+++ b/Tests/StructuredQueriesTests/TriggersTests.swift
@@ -117,7 +117,7 @@ extension SnapshotTests {
 
     @Test func afterUpdateTouchCustomDate() {
       assertQuery(
-        Reminder.createTemporaryTrigger(afterUpdateTouch: \.updatedAt, expression: "customDate()")
+        Reminder.createTemporaryTrigger(afterUpdateTouch: \.updatedAt, date: "customDate()")
       ) {
         """
         CREATE TEMPORARY TRIGGER

--- a/Tests/StructuredQueriesTests/TriggersTests.swift
+++ b/Tests/StructuredQueriesTests/TriggersTests.swift
@@ -117,7 +117,7 @@ extension SnapshotTests {
 
     @Test func afterUpdateTouchCustomDate() {
       assertQuery(
-        Reminder.createTemporaryTrigger(afterUpdateTouch: \.updatedAt, date: "customDate()")
+        Reminder.createTemporaryTrigger(afterUpdateTouch: \.updatedAt, date: #sql("customDate()"))
       ) {
         """
         CREATE TEMPORARY TRIGGER


### PR DESCRIPTION
Adds support for providing a customized expression that will be used when creating a temporary trigger.