### PR TITLE
Database Functions Improvements

### DIFF
--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/MigrationGuides.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/MigrationGuides.md
@@ -1,0 +1,17 @@
+# Migration guides
+
+Learn how to upgrade your application to the latest version of StructuredQueries.
+
+## Overview
+
+StructuredQueries is under constant development, and we are always looking for ways to simplify the
+library and make it more powerful. As such, we often need to deprecate certain APIs in favor of
+newer ones. We recommend people update their code as quickly as possible to the newest APIs, and
+these guides contain tips to do so.
+
+> Important: Before following any particular migration guide be sure you have followed all the
+> preceding migration guides.
+
+## Topics
+
+- <doc:MigratingTo0.16>

--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/MigrationGuides/MigratingTo0.16.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/MigrationGuides/MigratingTo0.16.md
@@ -13,8 +13,8 @@ For example, an `exclaim` function can be defined like so:
 
 ```swift
 @DatabaseFunction
-func exclaim(_ x: String) -> String {
-  x.localizedUppercase + "!"
+func exclaim(_ string: String) -> String {
+  string.localizedUppercase + "!"
 }
 ```
 

--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/MigrationGuides/MigratingTo0.16.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/MigrationGuides/MigratingTo0.16.md
@@ -1,0 +1,70 @@
+# Migrating to 0.16
+
+StructuredQueries 0.16 introduces powerful tools for user-defined SQLite functions, with some
+breaking changes for those defining custom query representations.
+
+## Overview
+
+StructuredQueries recently introduced a new module, StructuredQueriesSQLite, and with it a new macro
+for defining Swift functions that can be called from a query. It's called `@DatabaseFunction`, and
+can annotate any function that works with query-representable types.
+
+For example, an `exclaim` function can be defined like so:
+
+```swift
+@DatabaseFunction
+func exclaim(_ x: String) -> String {
+  x.localizedUppercase + "!"
+}
+```
+
+And will be immediately callable in a query by prefixing the function with `$`:
+
+```swift
+Reminder.select { $exclaim($0.title) }
+// SELECT "exclaim"("reminders"."title") FROM "reminders"
+```
+
+For the query to successfully execute, you must also add the function to your SQLite database
+connection. This can be done in [SharingGRDB] (0.7.0+) using the `Database.add(function:)` method,
+_e.g._ when you first configure things:
+
+[SharingGRDB]: https://github.com/pointfreeco/sharing-grdb
+
+```swift
+var configuration = Configuration()
+configuration.prepareDatabase { db in
+  db.add(function: $exclaim)
+}
+```
+
+> Tip: Use the `isDeterministic` parameter for functions that always return the same value from the
+> same arguments. SQLite can optimize these functions.
+>
+> ```swift
+> @DatabaseFunction(isDeterministic: true)
+> func exclaim(_ x: String) -> String {
+>   x.localizedUppercase + "!"
+> }
+> ```
+
+### Custom representations
+
+To define a type that works with a custom representation, like JSON, you can use the `as` parameter
+of the macro:
+
+```swift
+@DatabaseFunction(
+  as: (([String].JSONRepresentation) -> [String].JSONRepresentation).self
+)
+func jsonArrayExclaim(_ strings: [String]) -> [String] {
+  strings.map { $0.localizedUppercase + "!" }
+}
+```
+
+### Breaking change: user-defined representations
+
+To power things, a new initializer, ``QueryBindable/init(queryBinding:)``, was added to the
+``QueryBindable`` protocol. While most code should continue to compile, if you define your own
+query representations that conform to ``QueryRepresentable``, you will need to define this
+initializer upon upgrading.

--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/MigrationGuides/MigratingTo0.16.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/MigrationGuides/MigratingTo0.16.md
@@ -68,3 +68,16 @@ To power things, a new initializer, ``QueryBindable/init(queryBinding:)``, was a
 ``QueryBindable`` protocol. While most code should continue to compile, if you define your own
 query representations that conform to ``QueryRepresentable``, you will need to define this
 initializer upon upgrading.
+
+For example, `JSONRepresentation` added the following initializer:
+
+```swift
+public init?(queryBinding: QueryBinding) {
+  guard case .text(let json) = queryBinding else { return nil }
+  guard let queryOutput = try? jsonDecoder.decode(
+    QueryOutput.self, from: Data(json.utf8)
+  )
+  else { return nil }
+  self.init(queryOutput: queryOutput)
+}
+```

--- a/Sources/StructuredQueriesCore/Documentation.docc/StructuredQueriesCore.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/StructuredQueriesCore.md
@@ -140,3 +140,7 @@ reading to learn more about building SQL with StructuredQueries.
 
 - <doc:FullTextSearch>
 - <doc:Integration>
+
+### Migration guides
+
+- <doc:MigrationGuides>

--- a/Sources/StructuredQueriesCore/Internal/Deprecations.swift
+++ b/Sources/StructuredQueriesCore/Internal/Deprecations.swift
@@ -169,6 +169,14 @@ extension Date.ISO8601Representation: QueryBindable {
   public var queryBinding: QueryBinding {
     .text(queryOutput.iso8601String)
   }
+
+  public init?(queryBinding: QueryBinding) {
+    guard
+      case .text(let iso8601String) = queryBinding,
+      let queryOutput = try? Date(iso8601String: iso8601String)
+    else { return nil }
+    self.init(queryOutput: queryOutput)
+  }
 }
 
 @available(
@@ -225,6 +233,14 @@ extension UUID? {
 extension UUID.LowercasedRepresentation: QueryBindable {
   public var queryBinding: QueryBinding {
     .text(queryOutput.uuidString.lowercased())
+  }
+
+  public init?(queryBinding: QueryBinding) {
+    guard
+      case .text(let uuidString) = queryBinding,
+      let uuid = UUID(uuidString: uuidString)
+    else { return nil }
+    self.init(queryOutput: uuid)
   }
 }
 

--- a/Sources/StructuredQueriesCore/QueryBindable+Foundation.swift
+++ b/Sources/StructuredQueriesCore/QueryBindable+Foundation.swift
@@ -5,6 +5,11 @@ extension Data: QueryBindable {
     .blob([UInt8](self))
   }
 
+  public init?(queryBinding: QueryBinding) {
+    guard case .blob(let bytes) = queryBinding else { return nil }
+    self.init(bytes)
+  }
+
   public init(decoder: inout some QueryDecoder) throws {
     try self.init([UInt8](decoder: &decoder))
   }
@@ -13,6 +18,11 @@ extension Data: QueryBindable {
 extension URL: QueryBindable {
   public var queryBinding: QueryBinding {
     .text(absoluteString)
+  }
+
+  public init?(queryBinding: QueryBinding) {
+    guard case .text(let string) = queryBinding else { return nil }
+    self.init(string: string)
   }
 
   public init(decoder: inout some QueryDecoder) throws {

--- a/Sources/StructuredQueriesCore/QueryBindable.swift
+++ b/Sources/StructuredQueriesCore/QueryBindable.swift
@@ -16,11 +16,6 @@ public protocol QueryBindable: QueryRepresentable, QueryExpression where QueryVa
 
 extension QueryBindable {
   public var queryFragment: QueryFragment { "\(queryBinding)" }
-
-  public init?(queryBinding: QueryBinding) {
-    guard let queryValue = QueryValue(queryBinding: queryBinding) else { return nil }
-    self.init(queryBinding: queryValue.queryBinding)
-  }
 }
 
 extension [UInt8]: QueryBindable, QueryExpression {

--- a/Sources/StructuredQueriesCore/QueryBindable.swift
+++ b/Sources/StructuredQueriesCore/QueryBindable.swift
@@ -53,22 +53,42 @@ extension Date: QueryBindable {
 
 extension Float: QueryBindable {
   public var queryBinding: QueryBinding { .double(Double(self)) }
+  public init?(queryBinding: QueryBinding) {
+    guard case .double(let value) = queryBinding else { return nil }
+    self.init(value)
+  }
 }
 
 extension Int: QueryBindable {
   public var queryBinding: QueryBinding { .int(Int64(self)) }
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let value) = queryBinding else { return nil }
+    self.init(value)
+  }
 }
 
 extension Int8: QueryBindable {
   public var queryBinding: QueryBinding { .int(Int64(self)) }
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let value) = queryBinding else { return nil }
+    self.init(value)
+  }
 }
 
 extension Int16: QueryBindable {
   public var queryBinding: QueryBinding { .int(Int64(self)) }
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let value) = queryBinding else { return nil }
+    self.init(value)
+  }
 }
 
 extension Int32: QueryBindable {
   public var queryBinding: QueryBinding { .int(Int64(self)) }
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let value) = queryBinding else { return nil }
+    self.init(value)
+  }
 }
 
 extension Int64: QueryBindable {
@@ -89,14 +109,26 @@ extension String: QueryBindable {
 
 extension UInt8: QueryBindable {
   public var queryBinding: QueryBinding { .int(Int64(self)) }
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let value) = queryBinding else { return nil }
+    self.init(value)
+  }
 }
 
 extension UInt16: QueryBindable {
   public var queryBinding: QueryBinding { .int(Int64(self)) }
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let value) = queryBinding else { return nil }
+    self.init(value)
+  }
 }
 
 extension UInt32: QueryBindable {
   public var queryBinding: QueryBinding { .int(Int64(self)) }
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let value) = queryBinding else { return nil }
+    self.init(value)
+  }
 }
 
 extension UInt64: QueryBindable {
@@ -106,6 +138,10 @@ extension UInt64: QueryBindable {
     } else {
       return .int(Int64(self))
     }
+  }
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let value) = queryBinding, value >= UInt64.min else { return nil }
+    self.init(value)
   }
 }
 
@@ -146,8 +182,16 @@ extension DefaultStringInterpolation {
 
 extension QueryBindable where Self: LosslessStringConvertible {
   public var queryBinding: QueryBinding { description.queryBinding }
+  public init?(queryBinding: QueryBinding) {
+    guard let description = String(queryBinding: queryBinding) else { return nil }
+    self.init(description)
+  }
 }
 
 extension QueryBindable where Self: RawRepresentable, RawValue: QueryBindable {
   public var queryBinding: QueryBinding { rawValue.queryBinding }
+  public init?(queryBinding: QueryBinding) {
+    guard let rawValue = RawValue(queryBinding: queryBinding) else { return nil }
+    self.init(rawValue: rawValue)
+  }
 }

--- a/Sources/StructuredQueriesCore/QueryRepresentable/Codable+JSON.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/Codable+JSON.swift
@@ -6,15 +6,6 @@ public struct _CodableJSONRepresentation<QueryOutput: Codable>: QueryRepresentab
   public init(queryOutput: QueryOutput) {
     self.queryOutput = queryOutput
   }
-
-  public init(decoder: inout some QueryDecoder) throws {
-    self.init(
-      queryOutput: try jsonDecoder.decode(
-        QueryOutput.self,
-        from: Data(String(decoder: &decoder).utf8)
-      )
-    )
-  }
 }
 
 extension Decodable where Self: Encodable {
@@ -45,6 +36,24 @@ extension _CodableJSONRepresentation: QueryBindable {
     } catch {
       return .invalid(error)
     }
+  }
+
+  public init?(queryBinding: QueryBinding) {
+    guard case .text(let value) = queryBinding else { return nil }
+    guard let queryOutput = try? jsonDecoder.decode(QueryOutput.self, from: Data(value.utf8))
+    else { return nil }
+    self.init(queryOutput: queryOutput)
+  }
+}
+
+extension _CodableJSONRepresentation: QueryDecodable {
+  public init(decoder: inout some QueryDecoder) throws {
+    self.init(
+      queryOutput: try jsonDecoder.decode(
+        QueryOutput.self,
+        from: Data(String(decoder: &decoder).utf8)
+      )
+    )
   }
 }
 

--- a/Sources/StructuredQueriesCore/QueryRepresentable/Date+JulianDay.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/Date+JulianDay.swift
@@ -30,6 +30,11 @@ extension Date.JulianDayRepresentation: QueryBindable {
   public var queryBinding: QueryBinding {
     .double(2440587.5 + queryOutput.timeIntervalSince1970 / 86400)
   }
+
+  public init?(queryBinding: QueryBinding) {
+    guard case .double(let value) = queryBinding else { return nil }
+    self.init(queryOutput: Date(timeIntervalSince1970: (value - 2440587.5) * 86400))
+  }
 }
 
 extension Date.JulianDayRepresentation: QueryDecodable {

--- a/Sources/StructuredQueriesCore/QueryRepresentable/Date+UnixTime.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/Date+UnixTime.swift
@@ -30,6 +30,11 @@ extension Date.UnixTimeRepresentation: QueryBindable {
   public var queryBinding: QueryBinding {
     .int(Int64(queryOutput.timeIntervalSince1970))
   }
+
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let timeIntervalSince1970) = queryBinding else { return nil }
+    self.init(queryOutput: Date(timeIntervalSince1970: Double(timeIntervalSince1970)))
+  }
 }
 
 extension Date.UnixTimeRepresentation: QueryDecodable {

--- a/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Bytes.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Bytes.swift
@@ -30,6 +30,16 @@ extension UUID.BytesRepresentation: QueryBindable {
   public var queryBinding: QueryBinding {
     .blob(withUnsafeBytes(of: queryOutput.uuid, [UInt8].init))
   }
+
+  public init?(queryBinding: QueryBinding) {
+    guard case .blob(let bytes) = queryBinding else { return nil }
+    guard bytes.count == 16 else { return nil }
+    self.init(
+      queryOutput: bytes.withUnsafeBytes {
+        UUID(uuid: $0.load(as: uuid_t.self))
+      }
+    )
+  }
 }
 
 extension UUID.BytesRepresentation: QueryDecodable {

--- a/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Uppercased.swift
+++ b/Sources/StructuredQueriesCore/QueryRepresentable/UUID+Uppercased.swift
@@ -27,6 +27,14 @@ extension UUID? {
 }
 
 extension UUID.UppercasedRepresentation: QueryBindable {
+  public init?(queryBinding: QueryBinding) {
+    guard
+      case .text(let uuidString) = queryBinding,
+      let uuid = UUID(uuidString: uuidString)
+    else { return nil }
+    self.init(queryOutput: uuid)
+  }
+
   public var queryBinding: QueryBinding {
     .text(queryOutput.uuidString)
   }

--- a/Sources/StructuredQueriesCore/TableAlias.swift
+++ b/Sources/StructuredQueriesCore/TableAlias.swift
@@ -193,6 +193,11 @@ extension TableAlias: QueryBindable where Base: QueryBindable {
   public var queryBinding: QueryBinding {
     base.queryBinding
   }
+
+  public init?(queryBinding: QueryBinding) {
+    guard let base = Base(queryBinding: queryBinding) else { return nil }
+    self.init(base: base)
+  }
 }
 
 extension TableAlias: QueryDecodable where Base: QueryDecodable {

--- a/Sources/StructuredQueriesSQLite/Macros.swift
+++ b/Sources/StructuredQueriesSQLite/Macros.swift
@@ -16,3 +16,22 @@ public macro DatabaseFunction(
     module: "StructuredQueriesSQLiteMacros",
     type: "DatabaseFunctionMacro"
   )
+
+/// Defines and implements a conformance to the ``/StructuredQueriesSQLiteCore/DatabaseFunction``
+/// protocol.
+///
+/// - Parameters
+///   - name: The function's name. Defaults to the name of the function the macro is applied to.
+///   - representableFunctionType: The function as represented in a query.
+///   - isDeterministic: Whether or not the function is deterministic (or "pure" or "referentially
+///     transparent"), _i.e._ given an input it will always return the same output.
+@attached(peer, names: overloaded, prefixed(`$`))
+public macro DatabaseFunction<each T: QueryBindable, R: QueryBindable>(
+  _ name: String = "",
+  as representableFunctionType: ((repeat each T) -> R).Type,
+  isDeterministic: Bool = false
+) =
+  #externalMacro(
+    module: "StructuredQueriesSQLiteMacros",
+    type: "DatabaseFunctionMacro"
+  )

--- a/Sources/StructuredQueriesSQLiteCore/DatabaseFunction.swift
+++ b/Sources/StructuredQueriesSQLiteCore/DatabaseFunction.swift
@@ -20,6 +20,10 @@ public protocol DatabaseFunction<Input, Output> {
   var isDeterministic: Bool { get }
 }
 
+/// A type representing a scalar database function.
+///
+/// Don't conform to this protocol directly. Instead, use the `@DatabaseFunction` macro to generate
+/// a conformance.
 public protocol ScalarDatabaseFunction<Input, Output>: DatabaseFunction {
   /// The function body. Transforms an array of bindings handed to the function into a binding
   /// returned to the query.

--- a/Sources/StructuredQueriesSQLiteCore/Documentation.docc/Articles/CustomFunctions.md
+++ b/Sources/StructuredQueriesSQLiteCore/Documentation.docc/Articles/CustomFunctions.md
@@ -1,13 +1,13 @@
-# Migrating to 0.16
+# User-defined SQL functions
 
-StructuredQueries 0.16 introduces powerful tools for user-defined SQLite functions, with some
-breaking changes for those defining custom query representations.
+StructuredQueries comes with lightweight tools for defining Swift functions that can be called to
+from SQLite.
 
 ## Overview
 
-StructuredQueries recently introduced a new module, StructuredQueriesSQLite, and with it a new macro
-for defining Swift functions that can be called from a query. It's called `@DatabaseFunction`, and
-can annotate any function that works with query-representable types.
+StructuredQueries defines a macro specifically for defining Swift functions that can be called from
+a query. It's called `@DatabaseFunction`, and can annotate any function that works with
+query-representable types.
 
 For example, an `exclaim` function can be defined like so:
 
@@ -62,22 +62,9 @@ func jsonArrayExclaim(_ strings: [String]) -> [String] {
 }
 ```
 
-### Breaking change: user-defined representations
+## Topics
 
-To power things, a new initializer, ``QueryBindable/init(queryBinding:)``, was added to the
-``QueryBindable`` protocol. While most code should continue to compile, if you define your own
-query representations that conform to ``QueryRepresentable``, you will need to define this
-initializer upon upgrading.
+### Custom functions
 
-For example, `JSONRepresentation` added the following initializer:
-
-```swift
-public init?(queryBinding: QueryBinding) {
-  guard case .text(let json) = queryBinding else { return nil }
-  guard let queryOutput = try? jsonDecoder.decode(
-    QueryOutput.self, from: Data(json.utf8)
-  )
-  else { return nil }
-  self.init(queryOutput: queryOutput)
-}
-```
+- ``DatabaseFunction``
+- ``ScalarDatabaseFunction``

--- a/Sources/StructuredQueriesSQLiteMacros/DatabaseFunctionMacro.swift
+++ b/Sources/StructuredQueriesSQLiteMacros/DatabaseFunctionMacro.swift
@@ -33,14 +33,16 @@ extension DatabaseFunctionMacro: PeerMacro {
           message: MacroExpansionErrorMessage(
             "Missing required return type"
           ),
-          fixIt: .replaceChild(
+          fixIt: .replace(
             message: MacroExpansionFixItMessage("Insert '-> <#QueryBindable#>'"),
-            parent: declaration.signature,
-            replacingChildAt: \.returnClause,
-            with: ReturnClauseSyntax(
-              type: IdentifierTypeSyntax(name: "<#QueryBindable#>")
-                .with(\.leadingTrivia, .space)
-                .with(\.trailingTrivia, .space)
+            oldNode: declaration.signature,
+            newNode: declaration.signature.with(
+              \.returnClause,
+              ReturnClauseSyntax(
+                type: IdentifierTypeSyntax(name: "<#QueryBindable#>")
+                  .with(\.leadingTrivia, .space)
+                  .with(\.trailingTrivia, .space)
+              )
             )
           )
         )
@@ -73,16 +75,15 @@ extension DatabaseFunctionMacro: PeerMacro {
 
         case .some(let label) where label.text == "as":
           guard
-            let functionType = (
-              argument
+            let functionType =
+              (argument
               .expression.as(MemberAccessExprSyntax.self)?
               .base?.as(TupleExprSyntax.self)?
               .elements.only?
-              .trimmedDescription
-            )
-            .flatMap({
-              TypeSyntax(stringLiteral: $0).as(FunctionTypeSyntax.self)
-            }),
+              .trimmedDescription)
+              .flatMap({
+                TypeSyntax(stringLiteral: $0).as(FunctionTypeSyntax.self)
+              }),
             functionType.parameters.count == declaration.signature.parameterClause.parameters.count
           else {
             context.diagnose(

--- a/Sources/StructuredQueriesSQLiteMacros/DatabaseFunctionMacro.swift
+++ b/Sources/StructuredQueriesSQLiteMacros/DatabaseFunctionMacro.swift
@@ -177,7 +177,7 @@ extension DatabaseFunctionMacro: PeerMacro {
 
     var invocationBody = """
       \(functionRepresentation?.returnClause.type ?? outputType)(
-      queryOutput: body(\
+      queryOutput: self.body(\
       \(argumentBindings.indices.map { "n\($0).queryOutput" }.joined(separator: ", "))\
       )
       )
@@ -236,13 +236,13 @@ extension DatabaseFunctionMacro: PeerMacro {
       }
       public func callAsFunction\(signature.trimmed) {
       StructuredQueriesCore.SQLQueryExpression(
-      "\\(quote: name)(\(raw: parameters.map { "\\(\($0))" }.joined(separator: ", ")))"
+      "\\(quote: self.name)(\(raw: parameters.map { "\\(\($0))" }.joined(separator: ", ")))"
       )
       }
       public func invoke(
       _ arguments: [StructuredQueriesCore.QueryBinding]
       ) -> StructuredQueriesCore.QueryBinding {
-      guard arguments.count == argumentCount\
+      guard self.argumentCount == nil || self.argumentCount == arguments.count\
       \(raw: argumentBindings.map { ", \($0)" }.joined()) \
       else {
       return .invalid(InvalidInvocation())

--- a/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
@@ -35,17 +35,17 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Date> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             return Date(
-              queryOutput: body()
+              queryOutput: self.body()
             )
             .queryBinding
           }
@@ -86,17 +86,17 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Date> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             return Date(
-              queryOutput: body()
+              queryOutput: self.body()
             )
             .queryBinding
           }
@@ -137,17 +137,17 @@ extension SnapshotTests {
           }
           public func callAsFunction(_ strings: some StructuredQueriesCore.QueryExpression<[String].JSONRepresentation>) -> some StructuredQueriesCore.QueryExpression<[String].JSONRepresentation> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)(\(strings))"
+              "\(quote: self.name)(\(strings))"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount, let n0 = [String].JSONRepresentation(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = [String].JSONRepresentation(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return [String].JSONRepresentation(
-              queryOutput: body(n0.queryOutput)
+              queryOutput: self.body(n0.queryOutput)
             )
             .queryBinding
           }
@@ -188,17 +188,17 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Int> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             return Int(
-              queryOutput: body()
+              queryOutput: self.body()
             )
             .queryBinding
           }
@@ -239,17 +239,17 @@ extension SnapshotTests {
           }
           public func callAsFunction(_ format: some StructuredQueriesCore.QueryExpression<String>) -> some StructuredQueriesCore.QueryExpression<Date?> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)(\(format))"
+              "\(quote: self.name)(\(format))"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: body(n0.queryOutput)
+              queryOutput: self.body(n0.queryOutput)
             )
             .queryBinding
           }
@@ -290,17 +290,17 @@ extension SnapshotTests {
           }
           public func callAsFunction(format: some StructuredQueriesCore.QueryExpression<String>) -> some StructuredQueriesCore.QueryExpression<Date?> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)(\(format))"
+              "\(quote: self.name)(\(format))"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: body(n0.queryOutput)
+              queryOutput: self.body(n0.queryOutput)
             )
             .queryBinding
           }
@@ -341,17 +341,17 @@ extension SnapshotTests {
           }
           public func callAsFunction(_ format: some StructuredQueriesCore.QueryExpression<String> = "") -> some StructuredQueriesCore.QueryExpression<Date?> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)(\(format))"
+              "\(quote: self.name)(\(format))"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: body(n0.queryOutput)
+              queryOutput: self.body(n0.queryOutput)
             )
             .queryBinding
           }
@@ -392,17 +392,17 @@ extension SnapshotTests {
           }
           public func callAsFunction(format: some StructuredQueriesCore.QueryExpression<String> = "") -> some StructuredQueriesCore.QueryExpression<Date?> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)(\(format))"
+              "\(quote: self.name)(\(format))"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: body(n0.queryOutput)
+              queryOutput: self.body(n0.queryOutput)
             )
             .queryBinding
           }
@@ -443,17 +443,17 @@ extension SnapshotTests {
           }
           public func callAsFunction(first: some StructuredQueriesCore.QueryExpression<String> = "", second: some StructuredQueriesCore.QueryExpression<String> = "") -> some StructuredQueriesCore.QueryExpression<String> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)(\(first), \(second))"
+              "\(quote: self.name)(\(first), \(second))"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]), let n1 = String(queryBinding: arguments[1]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]), let n1 = String(queryBinding: arguments[1]) else {
               return .invalid(InvalidInvocation())
             }
             return String(
-              queryOutput: body(n0.queryOutput, n1.queryOutput)
+              queryOutput: self.body(n0.queryOutput, n1.queryOutput)
             )
             .queryBinding
           }
@@ -511,17 +511,17 @@ extension SnapshotTests {
           }
           public func callAsFunction(_ format: some StructuredQueriesCore.QueryExpression<String?> = String?.none) -> some StructuredQueriesCore.QueryExpression<Date?> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)(\(format))"
+              "\(quote: self.name)(\(format))"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount, let n0 = String?(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String?(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: body(n0.queryOutput)
+              queryOutput: self.body(n0.queryOutput)
             )
             .queryBinding
           }
@@ -562,18 +562,18 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Date> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             do {
               return try Date(
-                queryOutput: body()
+                queryOutput: self.body()
               )
               .queryBinding
             } catch {
@@ -617,18 +617,18 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Date> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             do {
               return try Date(
-                queryOutput: body()
+                queryOutput: self.body()
               )
               .queryBinding
             } catch {
@@ -672,17 +672,17 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Date> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             return Date(
-              queryOutput: body()
+              queryOutput: self.body()
             )
             .queryBinding
           }
@@ -723,17 +723,17 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Date> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             return Date(
-              queryOutput: body()
+              queryOutput: self.body()
             )
             .queryBinding
           }
@@ -797,17 +797,17 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Date> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             return Date(
-              queryOutput: body()
+              queryOutput: self.body()
             )
             .queryBinding
           }
@@ -848,17 +848,17 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Int> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             return Int(
-              queryOutput: body()
+              queryOutput: self.body()
             )
             .queryBinding
           }
@@ -916,17 +916,17 @@ extension SnapshotTests {
           }
           public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<<#QueryBindable#>> {
             StructuredQueriesCore.SQLQueryExpression(
-              "\(quote: name)()"
+              "\(quote: self.name)()"
             )
           }
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard arguments.count == argumentCount else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count else {
               return .invalid(InvalidInvocation())
             }
             return <#QueryBindable#>(
-              queryOutput: body()
+              queryOutput: self.body()
             )
             .queryBinding
           }

--- a/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
@@ -143,11 +143,11 @@ extension SnapshotTests {
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = [String].JSONRepresentation(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let strings = [String].JSONRepresentation(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return [String].JSONRepresentation(
-              queryOutput: self.body(n0.queryOutput)
+              queryOutput: self.body(strings.queryOutput)
             )
             .queryBinding
           }
@@ -245,11 +245,11 @@ extension SnapshotTests {
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let format = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: self.body(n0.queryOutput)
+              queryOutput: self.body(format.queryOutput)
             )
             .queryBinding
           }
@@ -296,11 +296,11 @@ extension SnapshotTests {
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let format = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: self.body(n0.queryOutput)
+              queryOutput: self.body(format.queryOutput)
             )
             .queryBinding
           }
@@ -347,11 +347,11 @@ extension SnapshotTests {
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let format = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: self.body(n0.queryOutput)
+              queryOutput: self.body(format.queryOutput)
             )
             .queryBinding
           }
@@ -398,11 +398,11 @@ extension SnapshotTests {
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let format = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: self.body(n0.queryOutput)
+              queryOutput: self.body(format.queryOutput)
             )
             .queryBinding
           }
@@ -449,11 +449,11 @@ extension SnapshotTests {
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String(queryBinding: arguments[0]), let n1 = String(queryBinding: arguments[1]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let first = String(queryBinding: arguments[0]), let second = String(queryBinding: arguments[1]) else {
               return .invalid(InvalidInvocation())
             }
             return String(
-              queryOutput: self.body(n0.queryOutput, n1.queryOutput)
+              queryOutput: self.body(first.queryOutput, second.queryOutput)
             )
             .queryBinding
           }
@@ -517,11 +517,11 @@ extension SnapshotTests {
           public func invoke(
             _ arguments: [StructuredQueriesCore.QueryBinding]
           ) -> StructuredQueriesCore.QueryBinding {
-            guard self.argumentCount == nil || self.argumentCount == arguments.count, let n0 = String?(queryBinding: arguments[0]) else {
+            guard self.argumentCount == nil || self.argumentCount == arguments.count, let format = String?(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
             return Date?(
-              queryOutput: self.body(n0.queryOutput)
+              queryOutput: self.body(format.queryOutput)
             )
             .queryBinding
           }

--- a/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
@@ -44,7 +44,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount else {
               return .invalid(InvalidInvocation())
             }
-            return body().queryBinding
+            return Date(
+              queryOutput: body()
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -92,7 +95,61 @@ extension SnapshotTests {
             guard arguments.count == argumentCount else {
               return .invalid(InvalidInvocation())
             }
-            return body().queryBinding
+            return Date(
+              queryOutput: body()
+            )
+            .queryBinding
+          }
+          private struct InvalidInvocation: Error {
+          }
+        }
+        """#
+      }
+    }
+
+    @Test func customRepresentation() {
+      assertMacro {
+        """
+        @DatabaseFunction(as: (([String].JSONRepresentation) -> [String].JSONRepresentation).self)
+        func jsonCapitalize(_ strings: [String]) -> [String] {
+          strings.map { $0.capitalized }
+        }
+        """
+      } expansion: {
+        #"""
+        func jsonCapitalize(_ strings: [String]) -> [String] {
+          strings.map { $0.capitalized }
+        }
+
+        var $jsonCapitalize: __macro_local_14jsonCapitalizefMu_ {
+          __macro_local_14jsonCapitalizefMu_(jsonCapitalize)
+        }
+
+        struct __macro_local_14jsonCapitalizefMu_: StructuredQueriesSQLiteCore.ScalarDatabaseFunction {
+          public typealias Input = [String]
+          public typealias Output = [String]
+          public let name = "jsonCapitalize"
+          public let argumentCount: Int? = 1
+          public let isDeterministic = false
+          public let body: ([String]) -> [String]
+          public init(_ body: @escaping ([String]) -> [String]) {
+            self.body = body
+          }
+          public func callAsFunction(_ strings: some StructuredQueriesCore.QueryExpression<[String].JSONRepresentation>) -> some StructuredQueriesCore.QueryExpression<[String].JSONRepresentation> {
+            StructuredQueriesCore.SQLQueryExpression(
+              "\(quote: name)(\(strings))"
+            )
+          }
+          public func invoke(
+            _ arguments: [StructuredQueriesCore.QueryBinding]
+          ) -> StructuredQueriesCore.QueryBinding {
+            guard arguments.count == argumentCount, let n0 = [String].JSONRepresentation(queryBinding: arguments[0]) else {
+              return .invalid(InvalidInvocation())
+            }
+            return [String].JSONRepresentation(
+              queryOutput: body(n0.queryOutput)
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -140,7 +197,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount else {
               return .invalid(InvalidInvocation())
             }
-            return body().queryBinding
+            return Int(
+              queryOutput: body()
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -188,7 +248,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
-            return body(n0).queryBinding
+            return Date?(
+              queryOutput: body(n0.queryOutput)
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -236,7 +299,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
-            return body(n0).queryBinding
+            return Date?(
+              queryOutput: body(n0.queryOutput)
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -284,7 +350,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
-            return body(n0).queryBinding
+            return Date?(
+              queryOutput: body(n0.queryOutput)
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -332,7 +401,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
-            return body(n0).queryBinding
+            return Date?(
+              queryOutput: body(n0.queryOutput)
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -380,7 +452,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount, let n0 = String(queryBinding: arguments[0]), let n1 = String(queryBinding: arguments[1]) else {
               return .invalid(InvalidInvocation())
             }
-            return body(n0, n1).queryBinding
+            return String(
+              queryOutput: body(n0.queryOutput, n1.queryOutput)
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -445,7 +520,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount, let n0 = String?(queryBinding: arguments[0]) else {
               return .invalid(InvalidInvocation())
             }
-            return body(n0).queryBinding
+            return Date?(
+              queryOutput: body(n0.queryOutput)
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -494,7 +572,10 @@ extension SnapshotTests {
               return .invalid(InvalidInvocation())
             }
             do {
-              return try body().queryBinding
+              return try Date(
+                queryOutput: body()
+              )
+              .queryBinding
             } catch {
               return .invalid(error)
             }
@@ -546,7 +627,10 @@ extension SnapshotTests {
               return .invalid(InvalidInvocation())
             }
             do {
-              return try body().queryBinding
+              return try Date(
+                queryOutput: body()
+              )
+              .queryBinding
             } catch {
               return .invalid(error)
             }
@@ -597,7 +681,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount else {
               return .invalid(InvalidInvocation())
             }
-            return body().queryBinding
+            return Date(
+              queryOutput: body()
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -645,7 +732,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount else {
               return .invalid(InvalidInvocation())
             }
-            return body().queryBinding
+            return Date(
+              queryOutput: body()
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -716,7 +806,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount else {
               return .invalid(InvalidInvocation())
             }
-            return body().queryBinding
+            return Date(
+              queryOutput: body()
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -764,7 +857,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount else {
               return .invalid(InvalidInvocation())
             }
-            return body().queryBinding
+            return Int(
+              queryOutput: body()
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }
@@ -829,7 +925,10 @@ extension SnapshotTests {
             guard arguments.count == argumentCount else {
               return .invalid(InvalidInvocation())
             }
-            return body().queryBinding
+            return <#QueryBindable#>(
+              queryOutput: body()
+            )
+            .queryBinding
           }
           private struct InvalidInvocation: Error {
           }

--- a/Tests/StructuredQueriesTests/DatabaseFunctionTests.swift
+++ b/Tests/StructuredQueriesTests/DatabaseFunctionTests.swift
@@ -208,5 +208,46 @@ extension SnapshotTests {
         """
       }
     }
+
+    @DatabaseFunction(as: (([String]?.JSONRepresentation) -> Int).self)
+    func jsonCount(_ strings: [String]?) -> Int {
+      strings?.count ?? -1
+    }
+
+    @Test func customNilRepresentation() {
+      @Dependency(\.defaultDatabase) var database
+      $jsonCount.install(database.handle)
+      assertQuery(
+        Values($jsonCount(#bind(["hello", "world", "goodnight", "moon"])))
+      ) {
+        """
+        SELECT "jsonCount"('[
+          "hello",
+          "world",
+          "goodnight",
+          "moon"
+        ]')
+        """
+      } results: {
+        """
+        ┌───┐
+        │ 4 │
+        └───┘
+        """
+      }
+      assertQuery(
+        Values($jsonCount(#bind(nil)))
+      ) {
+        """
+        SELECT "jsonCount"(NULL)
+        """
+      } results: {
+        """
+        ┌────┐
+        │ -1 │
+        └────┘
+        """
+      }
+    }
   }
 }

--- a/Tests/StructuredQueriesTests/DatabaseFunctionTests.swift
+++ b/Tests/StructuredQueriesTests/DatabaseFunctionTests.swift
@@ -123,5 +123,30 @@ extension SnapshotTests {
     func `default`() -> Int {
       42
     }
+
+    enum Completion: Int, QueryBindable {
+      case incomplete, complete, completing
+    }
+    @DatabaseFunction
+    func toggle(_ completion: Completion) -> Completion {
+      completion == .incomplete ? .completing : .incomplete
+    }
+    @Test func customToggle() {
+      @Dependency(\.defaultDatabase) var database
+      $toggle.install(database.handle)
+      assertQuery(
+        Values($toggle(Completion.incomplete))
+      ) {
+        """
+        SELECT "toggle"(0)
+        """
+      } results: {
+        """
+        ┌───────────────────────────────────────────────────────────┐
+        │ SnapshotTests.DatabaseFunctionTests.Completion.completing │
+        └───────────────────────────────────────────────────────────┘
+        """
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR improves upon a few deficiencies of #151:

1. It forces the definition of `QueryBindable.init?(queryBinding:)`. This is a breaking change for folks that define their own types conforming to `QueryRepresentable, but we are in the 0.x stage still, and custom query representations should be relatively uncommon. Still, we have a new migration guide to help.
2. It introduces an `as:` parameter to `@DatabaseFunction` for defining functions that work with custom query representations, like JSON.