### PR TITLE
Add support for `Void`-returning database functions

### DIFF
--- a/Sources/StructuredQueriesSQLite/Macros.swift
+++ b/Sources/StructuredQueriesSQLite/Macros.swift
@@ -35,3 +35,14 @@ public macro DatabaseFunction<each T: QueryBindable, R: QueryBindable>(
     module: "StructuredQueriesSQLiteMacros",
     type: "DatabaseFunctionMacro"
   )
+
+@attached(peer, names: overloaded, prefixed(`$`))
+public macro DatabaseFunction<each T: QueryBindable>(
+  _ name: String = "",
+  as representableFunctionType: ((repeat each T) -> Void).Type,
+  isDeterministic: Bool = false
+) =
+#externalMacro(
+  module: "StructuredQueriesSQLiteMacros",
+  type: "DatabaseFunctionMacro"
+)

--- a/Sources/StructuredQueriesSQLite/Macros.swift
+++ b/Sources/StructuredQueriesSQLite/Macros.swift
@@ -36,6 +36,14 @@ public macro DatabaseFunction<each T: QueryBindable, R: QueryBindable>(
     type: "DatabaseFunctionMacro"
   )
 
+/// Defines and implements a conformance to the ``/StructuredQueriesSQLiteCore/DatabaseFunction``
+/// protocol.
+///
+/// - Parameters
+///   - name: The function's name. Defaults to the name of the function the macro is applied to.
+///   - representableFunctionType: The function as represented in a query.
+///   - isDeterministic: Whether or not the function is deterministic (or "pure" or "referentially
+///     transparent"), _i.e._ given an input it will always return the same output.
 @attached(peer, names: overloaded, prefixed(`$`))
 public macro DatabaseFunction<each T: QueryBindable>(
   _ name: String = "",

--- a/Sources/StructuredQueriesSQLiteMacros/DatabaseFunctionMacro.swift
+++ b/Sources/StructuredQueriesSQLiteMacros/DatabaseFunctionMacro.swift
@@ -140,6 +140,7 @@ extension DatabaseFunctionMacro: PeerMacro {
     var inputType = bodyArguments.joined(separator: ", ")
     let isVoidReturning = signature.returnClause == nil
     let outputType = returnClause.type.trimmed
+    signature.returnClause = returnClause
     signature.returnClause?.type = (functionRepresentation?.returnClause ?? returnClause).type
       .asQueryExpression()
     let bodyReturnClause = " \(returnClause.trimmedDescription)"

--- a/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
@@ -897,7 +897,7 @@ extension SnapshotTests {
           public init(_ body: @escaping () -> Swift.Void) {
             self.body = body
           }
-          public func callAsFunction() {
+          public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Swift.Void> {
             StructuredQueriesCore.SQLQueryExpression(
               "\(quote: self.name)()"
             )
@@ -943,7 +943,7 @@ extension SnapshotTests {
           public init(_ body: @escaping () throws -> Swift.Void) {
             self.body = body
           }
-          public func callAsFunction() {
+          public func callAsFunction() -> some StructuredQueriesCore.QueryExpression<Swift.Void> {
             StructuredQueriesCore.SQLQueryExpression(
               "\(quote: self.name)()"
             )


### PR DESCRIPTION
A `@DatabaseFunction` that is `Void`-returning will return `NULL` to SQLite.