### PR TITLE
Functions should be generic over their query-representable types

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b5899dec35ccc82d161bdd4fd1114afbc74a459e1a742760fd9c65bc0582a716",
+  "originHash" : "06aba47229f3efe31fff79bc09af1ad2bc07a7df36bf0aa5433087c9340ac408",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -89,15 +89,6 @@
       "state" : {
         "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
         "version" : "601.0.1"
-      }
-    },
-    {
-      "identity" : "swift-tagged",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-tagged",
-      "state" : {
-        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
-        "version" : "0.10.0"
       }
     },
     {

--- a/Sources/StructuredQueriesCore/QueryBindable.swift
+++ b/Sources/StructuredQueriesCore/QueryBindable.swift
@@ -28,6 +28,10 @@ extension [UInt8]: QueryBindable, QueryExpression {
 
 extension Bool: QueryBindable {
   public var queryBinding: QueryBinding { .int(self ? 1 : 0) }
+  public init?(queryBinding: QueryBinding) {
+    guard case .int(let value) = queryBinding else { return nil }
+    self = value != 0
+  }
 }
 
 extension Double: QueryBindable {

--- a/Sources/StructuredQueriesSQLiteCore/DatabaseFunction.swift
+++ b/Sources/StructuredQueriesSQLiteCore/DatabaseFunction.swift
@@ -38,6 +38,7 @@ extension ScalarDatabaseFunction {
   ///
   /// - Parameter input: Expressions representing the arguments of the function.
   /// - Returns: An expression representing the function call.
+  @_disfavoredOverload
   public func callAsFunction<each T: QueryExpression>(
     _ input: repeat each T
   ) -> some QueryExpression<Output>

--- a/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
@@ -126,8 +126,8 @@ extension SnapshotTests {
         }
 
         struct __macro_local_14jsonCapitalizefMu_: StructuredQueriesSQLiteCore.ScalarDatabaseFunction {
-          public typealias Input = [String]
-          public typealias Output = [String]
+          public typealias Input = [String].JSONRepresentation
+          public typealias Output = [String].JSONRepresentation
           public let name = "jsonCapitalize"
           public let argumentCount: Int? = 1
           public let isDeterministic = false

--- a/Tests/StructuredQueriesTests/DatabaseFunctionTests.swift
+++ b/Tests/StructuredQueriesTests/DatabaseFunctionTests.swift
@@ -312,19 +312,18 @@ extension SnapshotTests {
       }
     }
 
-    @DatabaseFunction(as: ((Reminder.JSONRepresentation) -> Bool).self)
-    func isValid(_ reminder: Reminder) -> Bool {
-      !reminder.title.isEmpty
+    @DatabaseFunction(as: ((Reminder.JSONRepresentation, Bool) -> Bool).self)
+    func isValid(_ reminder: Reminder, _ override: Bool = false) -> Bool {
+      !reminder.title.isEmpty || override
     }
-
     @Test func jsonObject() {
       $isValid.install(database.handle)
 
       assertQuery(
-        Reminder.select { $isValid($0.jsonObject()) }.limit(1)
+        Reminder.select { $isValid($0.jsonObject(), true) }.limit(1)
       ) {
         """
-        SELECT "isValid"(json_object('id', json_quote("reminders"."id"), 'assignedUserID', json_quote("reminders"."assignedUserID"), 'dueDate', json_quote("reminders"."dueDate"), 'isCompleted', json(CASE "reminders"."isCompleted" WHEN 0 THEN 'false' WHEN 1 THEN 'true' END), 'isFlagged', json(CASE "reminders"."isFlagged" WHEN 0 THEN 'false' WHEN 1 THEN 'true' END), 'notes', json_quote("reminders"."notes"), 'priority', json_quote("reminders"."priority"), 'remindersListID', json_quote("reminders"."remindersListID"), 'title', json_quote("reminders"."title"), 'updatedAt', json_quote("reminders"."updatedAt")))
+        SELECT "isValid"(json_object('id', json_quote("reminders"."id"), 'assignedUserID', json_quote("reminders"."assignedUserID"), 'dueDate', json_quote("reminders"."dueDate"), 'isCompleted', json(CASE "reminders"."isCompleted" WHEN 0 THEN 'false' WHEN 1 THEN 'true' END), 'isFlagged', json(CASE "reminders"."isFlagged" WHEN 0 THEN 'false' WHEN 1 THEN 'true' END), 'notes', json_quote("reminders"."notes"), 'priority', json_quote("reminders"."priority"), 'remindersListID', json_quote("reminders"."remindersListID"), 'title', json_quote("reminders"."title"), 'updatedAt', json_quote("reminders"."updatedAt")), 1)
         FROM "reminders"
         LIMIT 1
         """

--- a/Tests/StructuredQueriesTests/DatabaseFunctionTests.swift
+++ b/Tests/StructuredQueriesTests/DatabaseFunctionTests.swift
@@ -271,5 +271,70 @@ extension SnapshotTests {
 
       #expect(logger.messages == ["Hello, world!"])
     }
+
+    @DatabaseFunction(as: (([Tag].JSONRepresentation) -> String).self)
+    func joinTags(_ tags: [Tag]) -> String {
+      tags.map(\.title).joined(separator: ", ")
+    }
+
+    @Test func jsonArray() {
+      $joinTags.install(database.handle)
+
+      assertQuery(
+        Reminder
+          .group(by: \.id)
+          .leftJoin(ReminderTag.all) { $0.id.eq($1.reminderID) }
+          .leftJoin(Tag.all) { $1.tagID.eq($2.id) }
+          .select { $joinTags($2.jsonGroupArray()) }
+      ) {
+        """
+        SELECT "joinTags"(json_group_array(CASE WHEN ("tags"."rowid" IS NOT NULL) THEN json_object('id', json_quote("tags"."id"), 'title', json_quote("tags"."title")) END) FILTER (WHERE ("tags"."id" IS NOT NULL)))
+        FROM "reminders"
+        LEFT JOIN "remindersTags" ON ("reminders"."id" = "remindersTags"."reminderID")
+        LEFT JOIN "tags" ON ("remindersTags"."tagID" = "tags"."id")
+        GROUP BY "reminders"."id"
+        """
+      } results: {
+        """
+        ┌─────────────────────┐
+        │ "someday, optional" │
+        │ "someday, optional" │
+        │ ""                  │
+        │ "car, kids"         │
+        │ ""                  │
+        │ ""                  │
+        │ ""                  │
+        │ ""                  │
+        │ ""                  │
+        │ ""                  │
+        └─────────────────────┘
+        """
+      }
+    }
+
+    @DatabaseFunction(as: ((Reminder.JSONRepresentation) -> Bool).self)
+    func isValid(_ reminder: Reminder) -> Bool {
+      !reminder.title.isEmpty
+    }
+
+    @Test func jsonObject() {
+      $isValid.install(database.handle)
+
+      assertQuery(
+        Reminder.select { $isValid($0.jsonObject()) }.limit(1)
+      ) {
+        """
+        SELECT "isValid"(json_object('id', json_quote("reminders"."id"), 'assignedUserID', json_quote("reminders"."assignedUserID"), 'dueDate', json_quote("reminders"."dueDate"), 'isCompleted', json(CASE "reminders"."isCompleted" WHEN 0 THEN 'false' WHEN 1 THEN 'true' END), 'isFlagged', json(CASE "reminders"."isFlagged" WHEN 0 THEN 'false' WHEN 1 THEN 'true' END), 'notes', json_quote("reminders"."notes"), 'priority', json_quote("reminders"."priority"), 'remindersListID', json_quote("reminders"."remindersListID"), 'title', json_quote("reminders"."title"), 'updatedAt', json_quote("reminders"."updatedAt")))
+        FROM "reminders"
+        LIMIT 1
+        """
+      } results: {
+        """
+        ┌──────┐
+        │ true │
+        └──────┘
+        """
+      }
+    }
   }
 }


### PR DESCRIPTION
Nice find by @acosmicflamingo.