### PR TITLE
Prefer explicit init in `selectStar` over bit-cast

### DIFF
--- a/Sources/StructuredQueriesCore/Statements/SelectStatement.swift
+++ b/Sources/StructuredQueriesCore/Statements/SelectStatement.swift
@@ -38,7 +38,7 @@ extension SelectStatement {
   public func selectStar<each J: Table>() -> Select<
     (From, repeat each J), From, (repeat each J)
   > where Joins == (repeat each J) {
-    unsafeBitCast(asSelect(), to: Select<(From, repeat each J), From, (repeat each J)>.self)
+    Select<(From, repeat each J), From, (repeat each J)>(clauses: _selectClauses)
   }
 }
 


### PR DESCRIPTION
Fixes #139.

Still not entirely sure how to repro, but should close out the above issue. /cc @coenttb