### PR TITLE
Add `Table.tableFragment` to support basic virtual table syntax

### DIFF
--- a/Sources/StructuredQueriesCore/Statements/Select.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select.swift
@@ -1752,7 +1752,7 @@ extension Select: SelectStatement {
     if let schemaName = From.schemaName {
       query.append("\(quote: schemaName).")
     }
-    query.append("\(quote: From.tableName)")
+    query.append(From.tableFragment)
     if let tableAlias = From.tableAlias {
       query.append(" AS \(quote: tableAlias)")
     }

--- a/Sources/StructuredQueriesCore/Table.swift
+++ b/Sources/StructuredQueriesCore/Table.swift
@@ -24,6 +24,9 @@ public protocol Table: QueryRepresentable where TableColumns.QueryValue == Self 
   /// The table schema's name.
   static var schemaName: String? { get }
 
+  /// A query fragment representing the table.
+  static var tableFragment: QueryFragment { get }
+
   /// A select statement for this table.
   ///
   /// The default implementation of this property returns a fully unscoped query for the table
@@ -93,6 +96,10 @@ extension Table {
 
   public static var schemaName: String? {
     nil
+  }
+
+  public static var tableFragment: QueryFragment {
+    QueryFragment(quote: tableName)
   }
 
   /// Returns a table column to the resulting value of a given key path.

--- a/Tests/StructuredQueriesTests/SelectTests.swift
+++ b/Tests/StructuredQueriesTests/SelectTests.swift
@@ -1437,6 +1437,111 @@ extension SnapshotTests {
       _ = base.count { r, _ in r.isCompleted }
       _ = base.map {}
     }
+
+    @Test func virtualTable() {
+      assertQuery(
+        PragmaTableInfo<Reminder>.all
+      ) {
+        """
+        SELECT "remindersTableInfo"."cid", "remindersTableInfo"."name", "remindersTableInfo"."type", "remindersTableInfo"."notnull", "remindersTableInfo"."dflt_value", "remindersTableInfo"."pk"
+        FROM pragma_table_info('reminders') AS "remindersTableInfo"
+        """
+      } results: {
+        #"""
+        ┌─────────────────────────────────────────┐
+        │ PragmaTableInfo(                        │
+        │   columnID: 0,                          │
+        │   name: "id",                           │
+        │   type: "INTEGER",                      │
+        │   isNotNull: true,                      │
+        │   defaultValue: nil,                    │
+        │   isPrimaryKey: true                    │
+        │ )                                       │
+        ├─────────────────────────────────────────┤
+        │ PragmaTableInfo(                        │
+        │   columnID: 1,                          │
+        │   name: "assignedUserID",               │
+        │   type: "INTEGER",                      │
+        │   isNotNull: false,                     │
+        │   defaultValue: nil,                    │
+        │   isPrimaryKey: false                   │
+        │ )                                       │
+        ├─────────────────────────────────────────┤
+        │ PragmaTableInfo(                        │
+        │   columnID: 2,                          │
+        │   name: "dueDate",                      │
+        │   type: "DATE",                         │
+        │   isNotNull: false,                     │
+        │   defaultValue: nil,                    │
+        │   isPrimaryKey: false                   │
+        │ )                                       │
+        ├─────────────────────────────────────────┤
+        │ PragmaTableInfo(                        │
+        │   columnID: 3,                          │
+        │   name: "isCompleted",                  │
+        │   type: "BOOLEAN",                      │
+        │   isNotNull: true,                      │
+        │   defaultValue: "0",                    │
+        │   isPrimaryKey: false                   │
+        │ )                                       │
+        ├─────────────────────────────────────────┤
+        │ PragmaTableInfo(                        │
+        │   columnID: 4,                          │
+        │   name: "isFlagged",                    │
+        │   type: "BOOLEAN",                      │
+        │   isNotNull: true,                      │
+        │   defaultValue: "0",                    │
+        │   isPrimaryKey: false                   │
+        │ )                                       │
+        ├─────────────────────────────────────────┤
+        │ PragmaTableInfo(                        │
+        │   columnID: 5,                          │
+        │   name: "remindersListID",              │
+        │   type: "INTEGER",                      │
+        │   isNotNull: true,                      │
+        │   defaultValue: nil,                    │
+        │   isPrimaryKey: false                   │
+        │ )                                       │
+        ├─────────────────────────────────────────┤
+        │ PragmaTableInfo(                        │
+        │   columnID: 6,                          │
+        │   name: "notes",                        │
+        │   type: "TEXT",                         │
+        │   isNotNull: true,                      │
+        │   defaultValue: "\'\'",                 │
+        │   isPrimaryKey: false                   │
+        │ )                                       │
+        ├─────────────────────────────────────────┤
+        │ PragmaTableInfo(                        │
+        │   columnID: 7,                          │
+        │   name: "priority",                     │
+        │   type: "INTEGER",                      │
+        │   isNotNull: false,                     │
+        │   defaultValue: nil,                    │
+        │   isPrimaryKey: false                   │
+        │ )                                       │
+        ├─────────────────────────────────────────┤
+        │ PragmaTableInfo(                        │
+        │   columnID: 8,                          │
+        │   name: "title",                        │
+        │   type: "TEXT",                         │
+        │   isNotNull: true,                      │
+        │   defaultValue: "\'\'",                 │
+        │   isPrimaryKey: false                   │
+        │ )                                       │
+        ├─────────────────────────────────────────┤
+        │ PragmaTableInfo(                        │
+        │   columnID: 9,                          │
+        │   name: "updatedAt",                    │
+        │   type: "TEXT",                         │
+        │   isNotNull: true,                      │
+        │   defaultValue: "datetime(\'subsec\')", │
+        │   isPrimaryKey: false                   │
+        │ )                                       │
+        └─────────────────────────────────────────┘
+        """#
+      }
+    }
   }
 }
 
@@ -1444,4 +1549,21 @@ extension Reminder.TableColumns {
   var isHighPriority: some QueryExpression<Bool> {
     self.priority == Priority.high
   }
+}
+
+@Table
+struct PragmaTableInfo<Base: Table> {
+  static var tableAlias: String? { "\(Base.tableName)TableInfo" }
+  static var schemaName: String? { Base.schemaName }
+
+  static var tableFragment: QueryFragment {
+    "pragma_table_info(\(quote: Base.tableName, delimiter: .text))"
+  }
+
+  @Column("cid") let columnID: Int
+  let name: String
+  let type: String
+  @Column("notnull") let isNotNull: Bool
+  @Column("dflt_value") let defaultValue: String?
+  @Column("pk") let isPrimaryKey: Bool
 }

--- a/Tests/StructuredQueriesTests/Support/Schema.swift
+++ b/Tests/StructuredQueriesTests/Support/Schema.swift
@@ -96,7 +96,7 @@ extension Database {
     try execute(
       """
       CREATE TABLE "remindersLists" (
-        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
         "color" INTEGER NOT NULL DEFAULT 4889071,
         "title" TEXT NOT NULL DEFAULT '',
         "position" INTEGER NOT NULL DEFAULT 0
@@ -111,7 +111,7 @@ extension Database {
     try execute(
       """
       CREATE TABLE "reminders" (
-        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "id" INTEGER NOT NULL  PRIMARY KEY AUTOINCREMENT,
         "assignedUserID" INTEGER,
         "dueDate" DATE,
         "isCompleted" BOOLEAN NOT NULL DEFAULT 0,


### PR DESCRIPTION
Makes it easier to generate virtual tables like `pragma_table_info`.