### PR TITLE
Fix deprecated ambiguous overload

### DIFF
--- a/Sources/StructuredQueriesSQLiteCore/Internal/Deprecations.swift
+++ b/Sources/StructuredQueriesSQLiteCore/Internal/Deprecations.swift
@@ -86,8 +86,11 @@ extension PrimaryKeyedTable {
   @available(
     *, deprecated, message: "Use a trailing closure, instead: 'Table.upsert { draft }'"
   )
-  public static func upsert(_ row: Draft) -> InsertOf<Self> {
-    upsert { row }
+  public static func upsert(
+    or conflictResolution: ConflictResolution,
+    _ row: Draft
+  ) -> InsertOf<Self> {
+    upsert(or: conflictResolution) { row }
   }
 }
 


### PR DESCRIPTION
We were using this API in a demo still. Let's fix the compiler ambiguity, though probably no rush to release a patch for this unless something else comes up.