### PR TITLE
FTS5: Support outer joins and aliased tables

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -92,6 +92,15 @@
       }
     },
     {
+      "identity" : "swift-tagged",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-tagged",
+      "state" : {
+        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
+        "version" : "0.10.0"
+      }
+    },
+    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",


### PR DESCRIPTION
Currently the helpers are only surfaced directly on a conformance. This commit extends the availability to optional tables and table aliases via conditional conformance.