### PR TITLE
Add type-safe API for creating temporary views

### DIFF
--- a/Sources/StructuredQueriesSQLiteCore/Documentation.docc/Articles/Views.md
+++ b/Sources/StructuredQueriesSQLiteCore/Documentation.docc/Articles/Views.md
@@ -1,0 +1,19 @@
+# Views
+
+Learn how to create views that can be queried.
+
+## Overview
+
+[Views](https://www.sqlite.org/lang_createview.html) are pre-packaged select statements that can
+be queried like a table. StructuredQueries comes with tools to create _temporary_ views in a
+type-safe and schema-safe fashion.
+
+## Topics
+
+### Creating temporary views
+
+- ``StructuredQueriesCore/Table/createTemporaryView(ifNotExists:as:)``
+
+### Views
+
+- ``TemporaryView``

--- a/Sources/StructuredQueriesSQLiteCore/Documentation.docc/StructuredQueriesSQLiteCore.md
+++ b/Sources/StructuredQueriesSQLiteCore/Documentation.docc/StructuredQueriesSQLiteCore.md
@@ -16,6 +16,7 @@ custom database functions, and more.
 - <doc:BuiltinFunctions>
 - <doc:CustomFunctions>
 - <doc:Triggers>
+- <doc:Views>
 - <doc:FullTextSearch>
 
 ### Query representations

--- a/Sources/StructuredQueriesSQLiteCore/Views.swift
+++ b/Sources/StructuredQueriesSQLiteCore/Views.swift
@@ -1,31 +1,27 @@
 extension Table where Self: _Selection {
-  /// A `CREATE TEMPORARY VIEW` statement that executes after a database event.
+  /// A `CREATE TEMPORARY VIEW` statement.
   ///
-  /// See <doc:Triggers> for more information.
-  ///
-  /// > Important: A name for the trigger is automatically derived from the arguments if one is not
-  /// > provided. If you build your own trigger helper that call this function, then your helper
-  /// > should also take `fileID`, `line` and `column` arguments and pass them to this function.
+  /// See <doc:Views> for more information.
   ///
   /// - Parameters:
-  ///   - name: The trigger's name. By default a unique name is generated depending using the table,
-  ///     operation, and source location.
-  ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE TRIGGER` statement.
-  ///   - operation: The trigger's operation.
-  ///   - fileID: The source `#fileID` associated with the trigger.
-  ///   - line: The source `#line` associated with the trigger.
-  ///   - column: The source `#column` associated with the trigger.
+  ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE VIEW` statement.
+  ///   - select: A statement describing the contents of the view.
   /// - Returns: A temporary trigger.
   public static func createTemporaryView<Selection: SelectStatement>(
     ifNotExists: Bool = false,
-    select: () -> Selection
-  ) -> DatabaseView<Self, Selection>
+    as select: Selection
+  ) -> TemporaryView<Self, Selection>
   where Selection.QueryValue == Columns.QueryValue {
-    DatabaseView(ifNotExists: ifNotExists, select: select())
+    TemporaryView(ifNotExists: ifNotExists, select: select)
   }
 }
 
-public struct DatabaseView<View: Table & _Selection, Selection: SelectStatement>: Statement
+/// A `CREATE TEMPORARY VIEW` statement.
+///
+/// This type of statement is returned from ``Table/createTemporaryView(ifNotExists:as:)``.
+///
+/// To learn more, see <doc:Views>.
+public struct TemporaryView<View: Table & _Selection, Selection: SelectStatement>: Statement
 where Selection.QueryValue == View {
   public typealias QueryValue = ()
   public typealias From = Never

--- a/Sources/StructuredQueriesSQLiteCore/Views.swift
+++ b/Sources/StructuredQueriesSQLiteCore/Views.swift
@@ -1,0 +1,70 @@
+extension Table where Self: _Selection {
+  /// A `CREATE TEMPORARY VIEW` statement that executes after a database event.
+  ///
+  /// See <doc:Triggers> for more information.
+  ///
+  /// > Important: A name for the trigger is automatically derived from the arguments if one is not
+  /// > provided. If you build your own trigger helper that call this function, then your helper
+  /// > should also take `fileID`, `line` and `column` arguments and pass them to this function.
+  ///
+  /// - Parameters:
+  ///   - name: The trigger's name. By default a unique name is generated depending using the table,
+  ///     operation, and source location.
+  ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE TRIGGER` statement.
+  ///   - operation: The trigger's operation.
+  ///   - fileID: The source `#fileID` associated with the trigger.
+  ///   - line: The source `#line` associated with the trigger.
+  ///   - column: The source `#column` associated with the trigger.
+  /// - Returns: A temporary trigger.
+  public static func createTemporaryView<Selection: SelectStatement>(
+    ifNotExists: Bool = false,
+    select: () -> Selection
+  ) -> DatabaseView<Self, Selection>
+  where Selection.QueryValue == Columns.QueryValue {
+    DatabaseView(ifNotExists: ifNotExists, select: select())
+  }
+}
+
+public struct DatabaseView<View: Table & _Selection, Selection: SelectStatement>: Statement
+where Selection.QueryValue == View {
+  public typealias QueryValue = ()
+  public typealias From = Never
+
+  fileprivate let ifNotExists: Bool
+  fileprivate let select: Selection
+
+  /// Returns a `DROP VIEW` statement for this trigger.
+  ///
+  /// - Parameter ifExists: Adds an `IF EXISTS` condition to the `DROP VIEW`.
+  /// - Returns: A `DROP VIEW` statement for this trigger.
+  public func drop(ifExists: Bool = false) -> some Statement<()> {
+    var query: QueryFragment = "DROP VIEW"
+    if ifExists {
+      query.append(" IF EXISTS")
+    }
+    query.append(" ")
+    if let schemaName = View.schemaName {
+      query.append("\(quote: schemaName).")
+    }
+    query.append(View.tableFragment)
+    return SQLQueryExpression(query)
+  }
+
+  public var query: QueryFragment {
+    var query: QueryFragment = "CREATE TEMPORARY VIEW"
+    if ifNotExists {
+      query.append(" IF NOT EXISTS")
+    }
+    query.append(.newlineOrSpace)
+    if let schemaName = View.schemaName {
+      query.append("\(quote: schemaName).")
+    }
+    query.append(View.tableFragment)
+    let columnNames: [QueryFragment] = View.TableColumns.allColumns
+      .map { "\(quote: $0.name)" }
+    query.append("\(.newlineOrSpace)(\(columnNames.joined(separator: ", ")))")
+    query.append("\(.newlineOrSpace)AS")
+    query.append("\(.newlineOrSpace)\(select)")
+    return query
+  }
+}

--- a/Tests/StructuredQueriesTests/ViewsTests.swift
+++ b/Tests/StructuredQueriesTests/ViewsTests.swift
@@ -1,0 +1,76 @@
+import Dependencies
+import Foundation
+import InlineSnapshotTesting
+import StructuredQueries
+import Testing
+import _StructuredQueriesSQLite
+
+extension SnapshotTests {
+  @Suite struct ViewsTests {
+    @Test func basics() {
+      let query = CompletedReminder.createTemporaryView {
+        Reminder
+          .where(\.isCompleted)
+          .select { CompletedReminder.Columns(reminderID: $0.id, title: $0.title) }
+      }
+      assertQuery(
+        query
+      ) {
+        """
+        CREATE TEMPORARY VIEW
+        "completedReminders"
+        ("reminderID", "title")
+        AS
+        SELECT "reminders"."id" AS "reminderID", "reminders"."title" AS "title"
+        FROM "reminders"
+        WHERE "reminders"."isCompleted"
+        """
+      } results: {
+        """
+
+        """
+      }
+      assertQuery(
+        CompletedReminder.limit(2)
+      ) {
+        """
+        SELECT "completedReminders"."reminderID", "completedReminders"."title"
+        FROM "completedReminders"
+        LIMIT 2
+        """
+      } results: {
+        """
+        ┌────────────────────────┐
+        │ CompletedReminder(     │
+        │   reminderID: 4,       │
+        │   title: "Take a walk" │
+        │ )                      │
+        ├────────────────────────┤
+        │ CompletedReminder(     │
+        │   reminderID: 7,       │
+        │   title: "Get laundry" │
+        │ )                      │
+        └────────────────────────┘
+        """
+      }
+      assertQuery(
+        query.drop()
+      ) {
+        """
+        DROP VIEW
+        "completedReminders"
+        """
+      }
+    }
+  }
+}
+
+@Table @Selection
+private struct CompletedReminder {
+  let reminderID: Reminder.ID
+  let title: String
+}
+
+extension Table where Self: _Selection {
+  static func foo() {}
+}

--- a/Tests/StructuredQueriesTests/ViewsTests.swift
+++ b/Tests/StructuredQueriesTests/ViewsTests.swift
@@ -8,11 +8,11 @@ import _StructuredQueriesSQLite
 extension SnapshotTests {
   @Suite struct ViewsTests {
     @Test func basics() {
-      let query = CompletedReminder.createTemporaryView {
-        Reminder
+      let query = CompletedReminder.createTemporaryView(
+        as: Reminder
           .where(\.isCompleted)
           .select { CompletedReminder.Columns(reminderID: $0.id, title: $0.title) }
-      }
+      )
       assertQuery(
         query
       ) {
@@ -57,8 +57,7 @@ extension SnapshotTests {
         query.drop()
       ) {
         """
-        DROP VIEW
-        "completedReminders"
+        DROP VIEW "completedReminders"
         """
       }
     }


### PR DESCRIPTION
Like temporary triggers
(https://github.com/pointfreeco/swift-structured-queries/pull/82), temporary views can be created in a completely type-safe manner due to their transitive nature.