### PR TITLE
Add CTE support to `createTemporaryView`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -92,15 +92,6 @@
       }
     },
     {
-      "identity" : "swift-tagged",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-tagged",
-      "state" : {
-        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
-        "version" : "0.10.0"
-      }
-    },
-    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",

--- a/Sources/StructuredQueriesSQLiteCore/Views.swift
+++ b/Sources/StructuredQueriesSQLiteCore/Views.swift
@@ -22,7 +22,7 @@ extension Table where Self: _Selection {
 ///
 /// To learn more, see <doc:Views>.
 public struct TemporaryView<View: Table & _Selection, Selection: PartialSelectStatement>: Statement
-where Selection.QueryValue == View.Columns.QueryValue {
+where Selection.QueryValue == View {
   public typealias QueryValue = ()
   public typealias From = Never
 

--- a/Sources/StructuredQueriesSQLiteCore/Views.swift
+++ b/Sources/StructuredQueriesSQLiteCore/Views.swift
@@ -7,7 +7,7 @@ extension Table where Self: _Selection {
   ///   - ifNotExists: Adds an `IF NOT EXISTS` clause to the `CREATE VIEW` statement.
   ///   - select: A statement describing the contents of the view.
   /// - Returns: A temporary trigger.
-  public static func createTemporaryView<Selection: SelectStatement>(
+  public static func createTemporaryView<Selection: PartialSelectStatement>(
     ifNotExists: Bool = false,
     as select: Selection
   ) -> TemporaryView<Self, Selection>
@@ -21,8 +21,8 @@ extension Table where Self: _Selection {
 /// This type of statement is returned from ``Table/createTemporaryView(ifNotExists:as:)``.
 ///
 /// To learn more, see <doc:Views>.
-public struct TemporaryView<View: Table & _Selection, Selection: SelectStatement>: Statement
-where Selection.QueryValue == View {
+public struct TemporaryView<View: Table & _Selection, Selection: PartialSelectStatement>: Statement
+where Selection.QueryValue == View.Columns.QueryValue {
   public typealias QueryValue = ()
   public typealias From = Never
 

--- a/Tests/StructuredQueriesTests/ViewsTests.swift
+++ b/Tests/StructuredQueriesTests/ViewsTests.swift
@@ -62,6 +62,34 @@ extension SnapshotTests {
         """
       }
     }
+
+    @Test func ctes() {
+      assertQuery(
+        CompletedReminder.createTemporaryView(
+          as: With {
+            Reminder
+              .where(\.isCompleted)
+              .select { CompletedReminder.Columns(reminderID: $0.id, title: $0.title) }
+          } query: {
+            CompletedReminder.all
+          }
+        )
+      ) {
+        """
+        CREATE TEMPORARY VIEW
+        "completedReminders"
+        ("reminderID", "title")
+        AS
+        WITH "completedReminders" AS (
+          SELECT "reminders"."id" AS "reminderID", "reminders"."title" AS "title"
+          FROM "reminders"
+          WHERE "reminders"."isCompleted"
+        )
+        SELECT "completedReminders"."reminderID", "completedReminders"."title"
+        FROM "completedReminders"
+        """
+      }
+    }
   }
 }
 
@@ -69,8 +97,4 @@ extension SnapshotTests {
 private struct CompletedReminder {
   let reminderID: Reminder.ID
   let title: String
-}
-
-extension Table where Self: _Selection {
-  static func foo() {}
 }


### PR DESCRIPTION
A common use case for views is more complex common table expressions.