### PR TITLE
Avoid automatic aliasing in queryFragment of _SelectedColumns

### DIFF
--- a/Sources/StructuredQueriesCore/_Selection.swift
+++ b/Sources/StructuredQueriesCore/_Selection.swift
@@ -8,6 +8,15 @@ public protocol _SelectedColumns<QueryValue>: QueryExpression {
 
 extension _SelectedColumns {
   public var queryFragment: QueryFragment {
-    selection.map { "\($1) AS \(quote: $0)" as QueryFragment }.joined(separator: ", ")
+    selection.map {
+      // Avoid aliasing fragments comprising multiple
+      // columns
+      //
+      // Atomic unit of a fragment seems to comprise 3 segments
+      // (e.g. [.sql("table"), .sql("."), .sql("column")].
+      $1.segments.count <= 3
+        ? "\($1) AS \(quote: $0)" as QueryFragment
+        : $1
+    }.joined(separator: ", ")
   }
 }


### PR DESCRIPTION
The `@Table` macro automatically generates a `queryFragment` property comprising a comma-delimited list of columns of said table. If the `@Selection` macro is applied to a struct whose type is of a `Table`, it will mean that when it comes time to generate the `SELECT` statement (which automatically applies aliasing to the elements of the selection list), one can get something like this: `SELECT media.id, media.title, media.artist as media`.