### PR TITLE
Support finding multiple rows by primary key.

### DIFF
--- a/Sources/StructuredQueriesCore/PrimaryKeyed.swift
+++ b/Sources/StructuredQueriesCore/PrimaryKeyed.swift
@@ -88,7 +88,7 @@ extension PrimaryKeyedTable {
   public static func find(
     _ primaryKey: some QueryExpression<TableColumns.PrimaryKey>
   ) -> Where<Self> {
-    Self.where { $0.primaryKey.eq(primaryKey) }
+    Self.where { $0.primaryKey.in([primaryKey]) }
   }
 
   public var primaryKey: PrimaryKey.QueryOutput {
@@ -105,7 +105,7 @@ extension TableDraft {
     _ primaryKey: some QueryExpression<PrimaryTable.TableColumns.PrimaryKey>
   ) -> Where<Self> {
     Self.where { _ in
-      PrimaryTable.columns.primaryKey.eq(primaryKey)
+      PrimaryTable.columns.primaryKey.in([primaryKey])
     }
   }
 }
@@ -116,7 +116,7 @@ extension Where where From: PrimaryKeyedTable {
   /// - Parameter primaryKey: A primary key.
   /// - Returns: A where clause with the added primary key.
   public func find(_ primaryKey: some QueryExpression<From.TableColumns.PrimaryKey>) -> Self {
-    self.where { $0.primaryKey.eq(primaryKey) }
+    self.where { $0.primaryKey.in([primaryKey]) }
   }
 }
 
@@ -127,8 +127,8 @@ extension Where where From: TableDraft {
   /// - Returns: A where clause with the added primary key.
   public func find(_ primaryKey: From.PrimaryTable.TableColumns.PrimaryKey.QueryOutput) -> Self {
     self.where { _ in
-      From.PrimaryTable.columns.primaryKey.eq(
-        From.PrimaryTable.TableColumns.PrimaryKey(queryOutput: primaryKey)
+      From.PrimaryTable.columns.primaryKey.in(
+        [From.PrimaryTable.TableColumns.PrimaryKey(queryOutput: primaryKey)]
       )
     }
   }
@@ -162,7 +162,7 @@ extension Update where From: PrimaryKeyedTable {
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: An update statement filtered by the given key.
   public func find(_ primaryKey: some QueryExpression<From.TableColumns.PrimaryKey>) -> Self {
-    self.where { $0.primaryKey.eq(primaryKey) }
+    self.where { $0.primaryKey.in([primaryKey]) }
   }
 }
 
@@ -173,8 +173,8 @@ extension Update where From: TableDraft {
   /// - Returns: An update statement filtered by the given key.
   public func find(_ primaryKey: From.PrimaryTable.TableColumns.PrimaryKey.QueryOutput) -> Self {
     self.where { _ in
-      From.PrimaryTable.columns.primaryKey.eq(
-        From.PrimaryTable.TableColumns.PrimaryKey(queryOutput: primaryKey)
+      From.PrimaryTable.columns.primaryKey.in(
+        [From.PrimaryTable.TableColumns.PrimaryKey(queryOutput: primaryKey)]
       )
     }
   }
@@ -186,7 +186,7 @@ extension Delete where From: PrimaryKeyedTable {
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: A delete statement filtered by the given key.
   public func find(_ primaryKey: some QueryExpression<From.TableColumns.PrimaryKey>) -> Self {
-    self.where { $0.primaryKey.eq(primaryKey) }
+    self.where { $0.primaryKey.in([primaryKey]) }
   }
 }
 
@@ -197,8 +197,8 @@ extension Delete where From: TableDraft {
   /// - Returns: A delete statement filtered by the given key.
   public func find(_ primaryKey: From.PrimaryTable.TableColumns.PrimaryKey.QueryOutput) -> Self {
     self.where { _ in
-      From.PrimaryTable.columns.primaryKey.eq(
-        From.PrimaryTable.TableColumns.PrimaryKey(queryOutput: primaryKey)
+      From.PrimaryTable.columns.primaryKey.in(
+        [From.PrimaryTable.TableColumns.PrimaryKey(queryOutput: primaryKey)]
       )
     }
   }

--- a/Sources/StructuredQueriesCore/PrimaryKeyed.swift
+++ b/Sources/StructuredQueriesCore/PrimaryKeyed.swift
@@ -114,9 +114,17 @@ extension TableDraft {
   public static func find(
     _ primaryKey: some QueryExpression<PrimaryTable.TableColumns.PrimaryKey>
   ) -> Where<Self> {
-    Self.where { _ in
-      PrimaryTable.columns.primaryKey.in([primaryKey])
-    }
+    Self.find([primaryKey])
+  }
+
+  /// A where clause filtered by primary keys.
+  ///
+  /// - Parameter primaryKeys: Primary keys identifying table rows.
+  /// - Returns: A `WHERE` clause.
+  public static func find(
+    _ primaryKeys: some Sequence<some QueryExpression<PrimaryTable.TableColumns.PrimaryKey>>
+  ) -> Where<Self> {
+    Self.where { $0.primaryKey.in(primaryKeys) }
   }
 }
 
@@ -126,7 +134,17 @@ extension Where where From: PrimaryKeyedTable {
   /// - Parameter primaryKey: A primary key.
   /// - Returns: A where clause with the added primary key.
   public func find(_ primaryKey: some QueryExpression<From.TableColumns.PrimaryKey>) -> Self {
-    self.where { $0.primaryKey.in([primaryKey]) }
+    self.find([primaryKey])
+  }
+
+  /// Adds a primary key condition to a where clause.
+  ///
+  /// - Parameter primaryKeys: A sequence of primary keys.
+  /// - Returns: A where clause with the added primary keys condition.
+  public func find(
+    _ primaryKeys: some Sequence<some QueryExpression<From.TableColumns.PrimaryKey>>
+  ) -> Self {
+    Self.where { $0.primaryKey.in(primaryKeys) }
   }
 }
 
@@ -136,7 +154,17 @@ extension Where where From: TableDraft {
   /// - Parameter primaryKey: A primary key.
   /// - Returns: A where clause with the added primary key.
   public func find(_ primaryKey: some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>) -> Self {
-    self.where { $0.primaryKey.in([primaryKey]) }
+    self.find([primaryKey])
+  }
+
+  /// Adds a primary key condition to a where clause.
+  ///
+  /// - Parameter primaryKeys: A sequence of primary keys.
+  /// - Returns: A where clause with the added primary keys condition.
+  public func find(
+    _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>>
+  ) -> Self {
+    Self.where { $0.primaryKey.in(primaryKeys) }
   }
 }
 
@@ -147,6 +175,16 @@ extension Select where From: PrimaryKeyedTable {
   /// - Returns: A select statement filtered by the given key.
   public func find(_ primaryKey: some QueryExpression<From.TableColumns.PrimaryKey>) -> Self {
     self.and(From.find(primaryKey))
+  }
+
+  /// A select statement filtered by a sequence of primary keys.
+  ///
+  /// - Parameter primaryKeys: A sequence of primary keys.
+  /// - Returns: A select statement filtered by the given keys.
+  public func find(
+    _ primaryKeys: some Sequence<some QueryExpression<From.TableColumns.PrimaryKey>>
+  ) -> Self {
+    self.and(From.find(primaryKeys))
   }
 }
 
@@ -160,6 +198,16 @@ extension Select where From: TableDraft {
   ) -> Self {
     self.and(From.find(primaryKey))
   }
+
+  /// A select statement filtered by a sequence of primary keys.
+  ///
+  /// - Parameter primaryKeys: A sequence of primary keys.
+  /// - Returns: A select statement filtered by the given keys.
+  public func find(
+    _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>>
+  ) -> Self {
+    self.and(From.find(primaryKeys))
+  }
 }
 
 extension Update where From: PrimaryKeyedTable {
@@ -168,7 +216,17 @@ extension Update where From: PrimaryKeyedTable {
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: An update statement filtered by the given key.
   public func find(_ primaryKey: some QueryExpression<From.TableColumns.PrimaryKey>) -> Self {
-    self.where { $0.primaryKey.in([primaryKey]) }
+    self.find([primaryKey])
+  }
+
+  /// An update statement filtered by a sequence of primary keys.
+  ///
+  /// - Parameter primaryKeys: A sequence of primary keys.
+  /// - Returns: An update statement filtered by the given keys.
+  public func find(
+    _ primaryKeys: some Sequence<some QueryExpression<From.TableColumns.PrimaryKey>>
+  ) -> Self {
+    self.where { $0.primaryKey.in(primaryKeys) }
   }
 }
 
@@ -178,7 +236,17 @@ extension Update where From: TableDraft {
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: An update statement filtered by the given key.
   public func find(_ primaryKey: some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>) -> Self {
-    self.where { $0.primaryKey.in([primaryKey]) }
+    self.find([primaryKey])
+  }
+
+  /// An update statement filtered by a sequence of primary keys.
+  ///
+  /// - Parameter primaryKeys: A sequence of primary keys.
+  /// - Returns: An update statement filtered by the given keys.
+  public func find(
+    _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>>
+  ) -> Self {
+    self.where { $0.primaryKey.in(primaryKeys) }
   }
 }
 
@@ -188,7 +256,17 @@ extension Delete where From: PrimaryKeyedTable {
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: A delete statement filtered by the given key.
   public func find(_ primaryKey: some QueryExpression<From.TableColumns.PrimaryKey>) -> Self {
-    self.where { $0.primaryKey.in([primaryKey]) }
+    self.find([primaryKey])
+  }
+
+  /// A delete statement filtered by a sequence of primary keys.
+  ///
+  /// - Parameter primaryKeys: A sequence of primary keys.
+  /// - Returns: A delete statement filtered by the given keys.
+  public func find(
+    _ primaryKeys: some Sequence<some QueryExpression<From.TableColumns.PrimaryKey>>
+  ) -> Self {
+    self.where { $0.primaryKey.in(primaryKeys) }
   }
 }
 
@@ -198,6 +276,16 @@ extension Delete where From: TableDraft {
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: A delete statement filtered by the given key.
   public func find(_ primaryKey: some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>) -> Self {
-    self.where { $0.primaryKey.in([primaryKey]) }
+    self.find([primaryKey])
+  }
+
+  /// A delete statement filtered by a sequence of primary keys.
+  ///
+  /// - Parameter primaryKeys: A sequence of primary keys.
+  /// - Returns: A delete statement filtered by the given keys.
+  public func find(
+    _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>>
+  ) -> Self {
+    self.where { $0.primaryKey.in(primaryKeys) }
   }
 }

--- a/Sources/StructuredQueriesCore/PrimaryKeyed.swift
+++ b/Sources/StructuredQueriesCore/PrimaryKeyed.swift
@@ -88,7 +88,17 @@ extension PrimaryKeyedTable {
   public static func find(
     _ primaryKey: some QueryExpression<TableColumns.PrimaryKey>
   ) -> Where<Self> {
-    Self.where { $0.primaryKey.in([primaryKey]) }
+    Self.find([primaryKey])
+  }
+
+  /// A where clause filtered by primary keys.
+  ///
+  /// - Parameter primaryKey: Primary keys identifying table rows.
+  /// - Returns: A `WHERE` clause.
+  public static func find(
+    _ primaryKeys: some Sequence<some QueryExpression<TableColumns.PrimaryKey>>
+  ) -> Where<Self> {
+    Self.where { $0.primaryKey.in(primaryKeys) }
   }
 
   public var primaryKey: PrimaryKey.QueryOutput {
@@ -125,12 +135,8 @@ extension Where where From: TableDraft {
   ///
   /// - Parameter primaryKey: A primary key.
   /// - Returns: A where clause with the added primary key.
-  public func find(_ primaryKey: From.PrimaryTable.TableColumns.PrimaryKey.QueryOutput) -> Self {
-    self.where { _ in
-      From.PrimaryTable.columns.primaryKey.in(
-        [From.PrimaryTable.TableColumns.PrimaryKey(queryOutput: primaryKey)]
-      )
-    }
+  public func find(_ primaryKey: some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>) -> Self {
+    self.where { $0.primaryKey.in([primaryKey]) }
   }
 }
 
@@ -171,12 +177,8 @@ extension Update where From: TableDraft {
   ///
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: An update statement filtered by the given key.
-  public func find(_ primaryKey: From.PrimaryTable.TableColumns.PrimaryKey.QueryOutput) -> Self {
-    self.where { _ in
-      From.PrimaryTable.columns.primaryKey.in(
-        [From.PrimaryTable.TableColumns.PrimaryKey(queryOutput: primaryKey)]
-      )
-    }
+  public func find(_ primaryKey: some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>) -> Self {
+    self.where { $0.primaryKey.in([primaryKey]) }
   }
 }
 
@@ -195,11 +197,7 @@ extension Delete where From: TableDraft {
   ///
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: A delete statement filtered by the given key.
-  public func find(_ primaryKey: From.PrimaryTable.TableColumns.PrimaryKey.QueryOutput) -> Self {
-    self.where { _ in
-      From.PrimaryTable.columns.primaryKey.in(
-        [From.PrimaryTable.TableColumns.PrimaryKey(queryOutput: primaryKey)]
-      )
-    }
+  public func find(_ primaryKey: some QueryExpression<From.PrimaryTable.TableColumns.PrimaryKey>) -> Self {
+    self.where { $0.primaryKey.in([primaryKey]) }
   }
 }

--- a/Tests/StructuredQueriesTests/PrimaryKeyedTableTests.swift
+++ b/Tests/StructuredQueriesTests/PrimaryKeyedTableTests.swift
@@ -148,6 +148,24 @@ extension SnapshotTests {
       }
 
       assertQuery(
+        Reminder.select { ($0.id, $0.title) }.find([2, 4, 6])
+      ) {
+        """
+        SELECT "reminders"."id", "reminders"."title"
+        FROM "reminders"
+        WHERE ("reminders"."id" IN (2, 4, 6))
+        """
+      } results: {
+        """
+        ┌───┬────────────────────────────┐
+        │ 2 │ "Haircut"                  │
+        │ 4 │ "Take a walk"              │
+        │ 6 │ "Pick up kids from school" │
+        └───┴────────────────────────────┘
+        """
+      }
+
+      assertQuery(
         Reminder.select { ($0.id, $0.title) }.find(Reminder.select(\.id))
       ) {
         """

--- a/Tests/StructuredQueriesTests/PrimaryKeyedTableTests.swift
+++ b/Tests/StructuredQueriesTests/PrimaryKeyedTableTests.swift
@@ -32,7 +32,7 @@ extension SnapshotTests {
         """
         UPDATE "reminders"
         SET "title" = ("reminders"."title" || '!!!')
-        WHERE ("reminders"."id" = 1)
+        WHERE ("reminders"."id" IN (1))
         RETURNING "title"
         """
       } results: {
@@ -50,7 +50,7 @@ extension SnapshotTests {
         """
         UPDATE "reminders"
         SET "title" = ("reminders"."title" || '???')
-        WHERE ("reminders"."id" = 1)
+        WHERE ("reminders"."id" IN (1))
         RETURNING "title"
         """
       } results: {
@@ -69,7 +69,7 @@ extension SnapshotTests {
       ) {
         """
         DELETE FROM "reminders"
-        WHERE ("reminders"."id" = 1)
+        WHERE ("reminders"."id" IN (1))
         RETURNING "reminders"."id"
         """
       } results: {
@@ -86,7 +86,7 @@ extension SnapshotTests {
       ) {
         """
         DELETE FROM "reminders"
-        WHERE ("reminders"."id" = 2)
+        WHERE ("reminders"."id" IN (2))
         RETURNING "reminders"."id"
         """
       } results: {
@@ -105,7 +105,7 @@ extension SnapshotTests {
         """
         SELECT "reminders"."id", "reminders"."title"
         FROM "reminders"
-        WHERE ("reminders"."id" = 1)
+        WHERE ("reminders"."id" IN (1))
         """
       } results: {
         """
@@ -121,7 +121,7 @@ extension SnapshotTests {
         """
         SELECT "reminders"."id", "reminders"."title"
         FROM "reminders"
-        WHERE ("reminders"."id" = 1)
+        WHERE ("reminders"."id" IN (1))
         """
       } results: {
         """
@@ -137,7 +137,7 @@ extension SnapshotTests {
         """
         SELECT "reminders"."id", "reminders"."title"
         FROM "reminders"
-        WHERE ("reminders"."id" = 2)
+        WHERE ("reminders"."id" IN (2))
         """
       } results: {
         """
@@ -148,12 +148,40 @@ extension SnapshotTests {
       }
 
       assertQuery(
+        Reminder.select { ($0.id, $0.title) }.find(Reminder.select(\.id))
+      ) {
+        """
+        SELECT "reminders"."id", "reminders"."title"
+        FROM "reminders"
+        WHERE ("reminders"."id" IN ((
+          SELECT "reminders"."id"
+          FROM "reminders"
+        )))
+        """
+      } results: {
+        """
+        ┌────┬────────────────────────────┐
+        │ 1  │ "Groceries"                │
+        │ 2  │ "Haircut"                  │
+        │ 3  │ "Doctor appointment"       │
+        │ 4  │ "Take a walk"              │
+        │ 5  │ "Buy concert tickets"      │
+        │ 6  │ "Pick up kids from school" │
+        │ 7  │ "Get laundry"              │
+        │ 8  │ "Take out trash"           │
+        │ 9  │ "Call accountant"          │
+        │ 10 │ "Send weekly emails"       │
+        └────┴────────────────────────────┘
+        """
+      }
+
+      assertQuery(
         Reminder.Draft.select { ($0.id, $0.title) }.find(2)
       ) {
         """
         SELECT "reminders"."id", "reminders"."title"
         FROM "reminders"
-        WHERE ("reminders"."id" = 2)
+        WHERE ("reminders"."id" IN (2))
         """
       } results: {
         """
@@ -175,7 +203,7 @@ extension SnapshotTests {
         SELECT "reminders"."title", "remindersLists"."title"
         FROM "reminders"
         JOIN "remindersLists" ON ("reminders"."remindersListID" = "remindersLists"."id")
-        WHERE ("reminders"."id" = 2)
+        WHERE ("reminders"."id" IN (2))
         """
       } results: {
         """
@@ -214,7 +242,7 @@ extension SnapshotTests {
         """
         SELECT "rows"."id", "rows"."isDeleted", "rows"."isNotDeleted"
         FROM "rows"
-        WHERE ("rows"."id" = '00000000-0000-0000-0000-000000000001')
+        WHERE ("rows"."id" IN ('00000000-0000-0000-0000-000000000001'))
         """
       } results: {
         """

--- a/Tests/StructuredQueriesTests/UpdateTests.swift
+++ b/Tests/StructuredQueriesTests/UpdateTests.swift
@@ -365,7 +365,7 @@ extension SnapshotTests {
         """
         UPDATE "reminders"
         SET "dueDate" = CASE WHEN ("reminders"."dueDate" IS NULL) THEN '2018-01-29 00:08:00.000' END
-        WHERE ("reminders"."id" = 1)
+        WHERE ("reminders"."id" IN (1))
         RETURNING "dueDate"
         """
       } results: {
@@ -383,7 +383,7 @@ extension SnapshotTests {
         """
         UPDATE "reminders"
         SET "dueDate" = CASE WHEN ("reminders"."dueDate" IS NULL) THEN '2018-01-29 00:08:00.000' END
-        WHERE ("reminders"."id" = 1)
+        WHERE ("reminders"."id" IN (1))
         RETURNING "dueDate"
         """
       } results: {

--- a/Tests/StructuredQueriesTests/WhereTests.swift
+++ b/Tests/StructuredQueriesTests/WhereTests.swift
@@ -225,7 +225,7 @@ extension SnapshotTests {
         SELECT "remindersLists"."id", "remindersLists"."color", "remindersLists"."title", "remindersLists"."position", "reminders"."id", "reminders"."assignedUserID", "reminders"."dueDate", "reminders"."isCompleted", "reminders"."isFlagged", "reminders"."notes", "reminders"."priority", "reminders"."remindersListID", "reminders"."title", "reminders"."updatedAt"
         FROM "remindersLists"
         LEFT JOIN "reminders" ON ("remindersLists"."id" = "reminders"."remindersListID")
-        WHERE ("remindersLists"."id" = 4) AND "reminders"."isCompleted"
+        WHERE ("remindersLists"."id" IN (4)) AND "reminders"."isCompleted"
         """
       } results: {
         """


### PR DESCRIPTION
We currently allow `Table.find(/*SELECT …*/)` but it will actually only find a single row, not all rows matching. So I've updated all of these types of queries to be "IN" instead of "=".

An alternative is to provide all new APIs for `findAll` if we want to distinguish between finding a single row versus finding many, but I'm not sure if there's a lot of benefit to that. It seems like it can be inferred from the argument provided to `find`.

Also I wonder if we should support `Table.find([1, 2, 3])`.