### PR TITLE
Fix warning on Swift 6.0

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -21,10 +21,6 @@ let package = Package(
       targets: ["StructuredQueriesCore"]
     ),
     .library(
-      name: "StructuredQueriesTestSupport",
-      targets: ["StructuredQueriesTestSupport"]
-    ),
-    .library(
       name: "StructuredQueriesSQLite",
       targets: ["StructuredQueriesSQLite"]
     ),

--- a/Tests/StructuredQueriesTests/ViewsTests.swift
+++ b/Tests/StructuredQueriesTests/ViewsTests.swift
@@ -241,7 +241,7 @@ extension SnapshotTests {
         """
         SELECT "reminderWithLists"."reminderID", "reminderWithLists"."reminderTitle", "reminderWithLists"."remindersListTitle"
         FROM "reminderWithLists"
-        WHERE ("reminderWithLists"."reminderID" = 1)
+        WHERE ("reminderWithLists"."reminderID" IN (1))
         """
       } results: {
         """


### PR DESCRIPTION
We had a merge issue bring in a duplicate target in the Package.swift file.