### PR TITLE
Unroll reduces to statements in macro expansion.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "64a0f70bd3bbae05e192502680e4627d94051e98f8d6895bb854e1fba892b8f7",
+  "originHash" : "b1e7fc8e75fb3f86eed27972a51c665f7e6482f3058b105c91aee6e1ad0b8018",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "5928286acce13def418ec36d05a001a9641086f2",
         "version" : "1.0.3"
-      }
-    },
-    {
-      "identity" : "swift-case-paths",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
-      "state" : {
-        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
-        "version" : "1.7.2"
       }
     },
     {
@@ -98,15 +89,6 @@
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"
-      }
-    },
-    {
-      "identity" : "swift-tagged",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-tagged",
-      "state" : {
-        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
-        "version" : "0.10.0"
       }
     },
     {

--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -868,7 +868,11 @@ extension TableMacro: ExtensionMacro {
       public typealias From = Swift.Never
       """,
     ])
-    let columnWidth: ExprSyntax = "[\(columnWidths, separator: ", ")].reduce(0, +)"
+    let columnWidth: ExprSyntax = """
+      var columnWidth = 0
+      columnWidth += \(columnWidths, separator: "; columnWidth += ")
+      return columnWidth
+      """
 
     return [
       DeclSyntax(

--- a/Sources/StructuredQueriesSQLiteMacros/DatabaseFunctionMacro.swift
+++ b/Sources/StructuredQueriesSQLiteMacros/DatabaseFunctionMacro.swift
@@ -228,7 +228,9 @@ extension DatabaseFunctionMacro: PeerMacro {
       public typealias Output = \(representableOutputType)
       public let name = \(databaseFunctionName)
       public var argumentCount: Int? { \
-      [\(raw: argumentCount.map { "\($0)._columnWidth" }.joined(separator: ", "))].reduce(0, +) \
+      var argumentCount = 0
+      argumentCount += \(raw: argumentCount.isEmpty ? "0" : argumentCount.map { "\($0)._columnWidth" }.joined(separator: "; argumentCount += "))
+      return argumentCount
       }
       public let isDeterministic = \(raw: isDeterministic)
       public let body: \(raw: bodyType)

--- a/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/DatabaseFunctionMacroTests.swift
@@ -28,7 +28,9 @@ extension SnapshotTests {
           public typealias Output = Date
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () -> Date
@@ -80,7 +82,9 @@ extension SnapshotTests {
           public typealias Output = Date
           public let name = "current_date"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () -> Date
@@ -132,7 +136,9 @@ extension SnapshotTests {
           public typealias Output = [String].JSONRepresentation
           public let name = "jsonCapitalize"
           public var argumentCount: Int? {
-            [[String].JSONRepresentation._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += [String].JSONRepresentation._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: ([String]) -> [String]
@@ -188,7 +194,9 @@ extension SnapshotTests {
           public typealias Output = Int
           public let name = "fortyTwo"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = true
           public let body: () -> Int
@@ -240,7 +248,9 @@ extension SnapshotTests {
           public typealias Output = Date?
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [String._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += String._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: (String) -> Date?
@@ -296,7 +306,9 @@ extension SnapshotTests {
           public typealias Output = Date?
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [String._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += String._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: (String) -> Date?
@@ -352,7 +364,9 @@ extension SnapshotTests {
           public typealias Output = Date?
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [String._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += String._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: (String) -> Date?
@@ -408,7 +422,9 @@ extension SnapshotTests {
           public typealias Output = Date?
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [String._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += String._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: (String) -> Date?
@@ -464,7 +480,10 @@ extension SnapshotTests {
           public typealias Output = String
           public let name = "concat"
           public var argumentCount: Int? {
-            [String._columnWidth, String._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += String._columnWidth;
+            argumentCount += String._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: (String, String) -> String
@@ -541,7 +560,9 @@ extension SnapshotTests {
           public typealias Output = Date?
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [String?._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += String?._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: (String?) -> Date?
@@ -597,7 +618,9 @@ extension SnapshotTests {
           public typealias Output = Date
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () throws -> Date
@@ -653,7 +676,9 @@ extension SnapshotTests {
           public typealias Output = Date
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () throws(MyError) -> Date
@@ -709,7 +734,9 @@ extension SnapshotTests {
           public typealias Output = Date
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () -> Date
@@ -761,7 +788,9 @@ extension SnapshotTests {
           public typealias Output = Date
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () -> Date
@@ -836,7 +865,9 @@ extension SnapshotTests {
           public typealias Output = Date
           public let name = "currentDate"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () -> Date
@@ -888,7 +919,9 @@ extension SnapshotTests {
           public typealias Output = Int
           public let name = "default"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () -> Int
@@ -940,7 +973,9 @@ extension SnapshotTests {
           public typealias Output = Swift.Void
           public let name = "void"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () -> Swift.Void
@@ -987,7 +1022,9 @@ extension SnapshotTests {
           public typealias Output = Swift.Void
           public let name = "void"
           public var argumentCount: Int? {
-            [].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += 0
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: () throws -> Swift.Void
@@ -1047,7 +1084,10 @@ extension SnapshotTests {
           public typealias Output = Swift.Void
           public let name = "min"
           public var argumentCount: Int? {
-            [Int._columnWidth, Int._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += Int._columnWidth;
+            argumentCount += Int._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: (Int, Int) -> Swift.Void
@@ -1111,7 +1151,10 @@ extension SnapshotTests {
           public typealias Output = Swift.Void
           public let name = "min"
           public var argumentCount: Int? {
-            [Int._columnWidth, Int._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += Int._columnWidth;
+            argumentCount += Int._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: (Int, Int) -> Swift.Void
@@ -1172,7 +1215,10 @@ extension SnapshotTests {
           public typealias Output = Bool
           public let name = "isValid"
           public var argumentCount: Int? {
-            [Reminder._columnWidth, Bool._columnWidth].reduce(0, +)
+            var argumentCount = 0
+            argumentCount += Reminder._columnWidth;
+            argumentCount += Bool._columnWidth
+            return argumentCount
           }
           public let isDeterministic = false
           public let body: (Reminder, Bool) -> Bool

--- a/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
@@ -56,7 +56,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -124,7 +126,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -296,7 +300,11 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Int?._columnWidth, String?._columnWidth, Int._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Int?._columnWidth;
+              columnWidth += String?._columnWidth;
+              columnWidth += Int._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -337,7 +345,11 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth, String?._columnWidth, Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth;
+            columnWidth += String?._columnWidth;
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "users"
@@ -411,7 +423,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foo"
@@ -519,7 +533,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "bar"
@@ -649,7 +665,12 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Swift.Bool._columnWidth, Swift.Int._columnWidth, Swift.Double._columnWidth, Swift.String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Swift.Bool._columnWidth;
+            columnWidth += Swift.Int._columnWidth;
+            columnWidth += Swift.Double._columnWidth;
+            columnWidth += Swift.String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -717,7 +738,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -830,7 +853,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Date.UnixTimeRepresentation._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Date.UnixTimeRepresentation._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -904,7 +929,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [String._columnWidth, String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += String._columnWidth;
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "users"
@@ -1002,7 +1030,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [String._columnWidth, String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += String._columnWidth;
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "users"
@@ -1128,7 +1159,10 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Int?._columnWidth, String._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Int?._columnWidth;
+              columnWidth += String._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -1165,7 +1199,11 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth, String._columnWidth, Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth;
+            columnWidth += String._columnWidth;
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "users"
@@ -1245,7 +1283,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -1315,7 +1355,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -1383,7 +1425,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -1451,7 +1495,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [ID<Foo>._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += ID<Foo>._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -1519,7 +1565,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += ._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -1632,7 +1680,10 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [ID<User, UUID.BytesRepresentation>?._columnWidth, ID<User, UUID.BytesRepresentation>?._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += ID<User, UUID.BytesRepresentation>?._columnWidth;
+              columnWidth += ID<User, UUID.BytesRepresentation>?._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -1665,7 +1716,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [ID<User, UUID.BytesRepresentation>._columnWidth, ID<User, UUID.BytesRepresentation>?._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += ID<User, UUID.BytesRepresentation>._columnWidth;
+            columnWidth += ID<User, UUID.BytesRepresentation>?._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "users"
@@ -1736,7 +1790,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "syncUps"
@@ -1853,7 +1909,10 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Int?._columnWidth, String._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Int?._columnWidth;
+              columnWidth += String._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -1890,7 +1949,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth, String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth;
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "syncUps"
@@ -2026,7 +2088,10 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Int?._columnWidth, <#Type#>._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Int?._columnWidth;
+              columnWidth += <#Type#>._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -2059,7 +2124,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth, <#Type#>._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth;
+            columnWidth += <#Type#>._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "syncUps"
@@ -2189,7 +2257,11 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Int?._columnWidth, Color.HexRepresentation._columnWidth, Swift.String._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Int?._columnWidth;
+              columnWidth += Color.HexRepresentation._columnWidth;
+              columnWidth += Swift.String._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -2226,7 +2298,11 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth, Color.HexRepresentation._columnWidth, Swift.String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth;
+            columnWidth += Color.HexRepresentation._columnWidth;
+            columnWidth += Swift.String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "remindersLists"
@@ -2319,7 +2395,9 @@ extension SnapshotTests {
           TableColumns()
         }
         public nonisolated static var _columnWidth: Int {
-          [String._columnWidth].reduce(0, +)
+          var columnWidth = 0
+          columnWidth += String._columnWidth
+          return columnWidth
         }
         public nonisolated static var tableName: String {
           "foos"
@@ -2940,7 +3018,9 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Int?._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Int?._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -2969,7 +3049,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -3073,7 +3155,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             Foo.tableName
@@ -3199,7 +3283,10 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Int?._columnWidth, String._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Int?._columnWidth;
+              columnWidth += String._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -3236,7 +3323,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth, String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth;
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "foos"
@@ -3383,7 +3473,12 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Int?._columnWidth, Swift.String._columnWidth, Date.UnixTimeRepresentation?._columnWidth, Priority?._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Int?._columnWidth;
+              columnWidth += Swift.String._columnWidth;
+              columnWidth += Date.UnixTimeRepresentation?._columnWidth;
+              columnWidth += Priority?._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -3424,7 +3519,12 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth, Swift.String._columnWidth, Date.UnixTimeRepresentation?._columnWidth, Priority?._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth;
+            columnWidth += Swift.String._columnWidth;
+            columnWidth += Date.UnixTimeRepresentation?._columnWidth;
+            columnWidth += Priority?._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "reminders"
@@ -3530,7 +3630,9 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [UUID.BytesRepresentation?._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += UUID.BytesRepresentation?._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -3559,7 +3661,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [UUID.BytesRepresentation._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += UUID.BytesRepresentation._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "reminders"
@@ -3628,7 +3732,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "reminders"
@@ -3743,7 +3849,10 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Int?._columnWidth, Swift.String._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Int?._columnWidth;
+              columnWidth += Swift.String._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -3776,7 +3885,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Int?._columnWidth, Swift.String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Int?._columnWidth;
+            columnWidth += Swift.String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "reminders"
@@ -3889,7 +4001,10 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [UUID?._columnWidth, Timestamps._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += UUID?._columnWidth;
+              columnWidth += Timestamps._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -3926,7 +4041,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [UUID._columnWidth, Timestamps._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += UUID._columnWidth;
+            columnWidth += Timestamps._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "rows"
@@ -4034,7 +4152,9 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [ReminderTagID?._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += ReminderTagID?._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -4063,7 +4183,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [ReminderTagID._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += ReminderTagID._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "remindersTags"
@@ -4192,7 +4314,11 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [Reminder.ID?._columnWidth, String._columnWidth, String._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += Reminder.ID?._columnWidth;
+              columnWidth += String._columnWidth;
+              columnWidth += String._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -4237,7 +4363,11 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Reminder.ID._columnWidth, String._columnWidth, String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Reminder.ID._columnWidth;
+            columnWidth += String._columnWidth;
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "reminderWithLists"
@@ -4362,7 +4492,10 @@ extension SnapshotTests {
             }
 
             public nonisolated static var _columnWidth: Int {
-              [MetadataID?._columnWidth, Date._columnWidth].reduce(0, +)
+              var columnWidth = 0
+              columnWidth += MetadataID?._columnWidth;
+              columnWidth += Date._columnWidth
+              return columnWidth
             }
 
             public nonisolated static var tableName: String {
@@ -4399,7 +4532,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [MetadataID._columnWidth, Date._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += MetadataID._columnWidth;
+            columnWidth += Date._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "metadatas"

--- a/Tests/StructuredQueriesTests/CompileTimeTests.swift
+++ b/Tests/StructuredQueriesTests/CompileTimeTests.swift
@@ -1,4 +1,5 @@
 import StructuredQueries
+import StructuredQueriesSQLite
 
 // NB: This is a compile-time test for a 'select' overload.
 @Table
@@ -46,4 +47,51 @@ struct TableWithComments {
   var email: String? = ""  // TODO: Should this be non-optional?
   /// The user's age.
   var age: Int
+}
+
+@Table private struct StructTableWithManyFields {
+  var a1: Foo?
+  var a2: Foo?
+  var a3: Foo?
+  var a4: Foo?
+  var a5: Foo?
+  var a6: Foo?
+  var a7: Foo?
+  var a8: Foo?
+  var a9: Foo?
+  var a10: Foo?
+  var a11: Foo?
+  var a12: Foo?
+}
+
+@Selection private struct StructSelectionWithManyFields {
+  var a1: Foo?
+  var a2: Foo?
+  var a3: Foo?
+  var a4: Foo?
+  var a5: Foo?
+  var a6: Foo?
+  var a7: Foo?
+  var a8: Foo?
+  var a9: Foo?
+  var a10: Foo?
+  var a11: Foo?
+  var a12: Foo?
+}
+
+@DatabaseFunction
+private func functionWithLotsOfArguments(
+  a1: Foo?,
+  a2: Foo?,
+  a3: Foo?,
+  a4: Foo?,
+  a5: Foo?,
+  a6: Foo?,
+  a7: Foo?,
+  a8: Foo?,
+  a9: Foo?,
+  a10: Foo?,
+  a11: Foo?,
+  a12: Foo?
+) {
 }

--- a/Tests/StructuredQueriesTests/TriggersTests.swift
+++ b/Tests/StructuredQueriesTests/TriggersTests.swift
@@ -131,7 +131,7 @@ extension SnapshotTests {
       ) {
         """
         CREATE TEMPORARY TRIGGER
-          "after_update_on_episodes@StructuredQueriesTests/TriggersTests.swift:129:39"
+          "after_update_on_episodes@StructuredQueriesTests/TriggersTests.swift:130:39"
         AFTER UPDATE ON "episodes"
         FOR EACH ROW BEGIN
           UPDATE "episodes"
@@ -148,7 +148,7 @@ extension SnapshotTests {
       ) {
         """
         CREATE TEMPORARY TRIGGER
-          "after_update_on_reminders@StructuredQueriesTests/TriggersTests.swift:146:40"
+          "after_update_on_reminders@StructuredQueriesTests/TriggersTests.swift:147:40"
         AFTER UPDATE ON "reminders"
         FOR EACH ROW BEGIN
           UPDATE "reminders"
@@ -177,7 +177,7 @@ extension SnapshotTests {
       assertQuery(trigger) {
         """
         CREATE TEMPORARY TRIGGER
-          "after_insert_on_remindersLists@StructuredQueriesTests/TriggersTests.swift:162:57"
+          "after_insert_on_remindersLists@StructuredQueriesTests/TriggersTests.swift:163:57"
         AFTER INSERT ON "remindersLists"
         FOR EACH ROW BEGIN
           UPDATE "remindersLists"


### PR DESCRIPTION
With our latest changes we have macro code that expands to computing a big array and then `reduce`ing on it. That can cause the compiler to error out because it takes too long to type check. So I've unrolled those `reduce`s to be just a bunch of statements.