### PR TITLE
Fix macro-generated code for enum selections

### DIFF
--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -913,7 +913,7 @@ extension TableMacro: MemberMacro {
       [(name: TokenSyntax, firstName: TokenSyntax, type: TypeSyntax?, default: ExprSyntax?)] = []
     var allColumnNames: [TokenSyntax] = []
     var writableColumns: [TokenSyntax] = []
-    var selectedColumns: [TokenSyntax] = []
+    var selectedColumns: [(name: TokenSyntax, type: TypeSyntax?)] = []
     var columnsProperties: [DeclSyntax] = []
     var expansionFailed = false
 
@@ -1045,7 +1045,7 @@ extension TableMacro: MemberMacro {
           )
         }
 
-        selectedColumns.append(identifier)
+        selectedColumns.append((identifier, columnQueryValueType))
 
         if !isGenerated {
           // NB: A compiler bug prevents us from applying the '@_Draft' macro directly
@@ -1190,7 +1190,7 @@ extension TableMacro: MemberMacro {
 
       let selectionAssignment =
         selectedColumns
-        .map { "allColumns.append(contentsOf: \($0)._allColumns)\n" }
+        .map { c, _ in "allColumns.append(contentsOf: \(c)._allColumns)\n" }
         .joined()
 
       selectionInitializers.append(
@@ -1268,7 +1268,7 @@ extension TableMacro: MemberMacro {
           }
         }
 
-        selectedColumns.append(identifier)
+        selectedColumns.append((identifier, columnQueryValueType))
 
         let defaultValue = parameter.defaultValue?.value.rewritten(selfRewriter)
         let tableColumnType =
@@ -1312,7 +1312,7 @@ extension TableMacro: MemberMacro {
           argument.append(" = \(type)(queryOutput: \(defaultValue))")
         }
         let staticColumns = selectedColumns.map {
-          $0 == identifier ? "\($0)" : "\(valueType)?(queryOutput: nil)" as ExprSyntax
+          $0 == identifier ? "\($0)" : "\($1)?(queryOutput: nil)" as ExprSyntax
         }
         let staticInitialization =
           staticColumns
@@ -1469,7 +1469,7 @@ extension TableMacro: MemberMacro {
       \(raw: writableColumnsAssignment)return writableColumns
       }
       public var queryFragment: QueryFragment {
-      "\(raw: selectedColumns.map { #"\(self.\#($0))"# }.joined(separator: ", "))"
+      "\(raw: selectedColumns.map { c, _ in #"\(self.\#(c))"# }.joined(separator: ", "))"
       }
       }
       """,

--- a/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
@@ -2453,7 +2453,7 @@ extension SnapshotTests {
             }
           }
 
-          public struct Selection: StructuredQueriesCore.TableExpression {
+          public nonisolated struct Selection: StructuredQueriesCore.TableExpression {
             public typealias QueryValue = Post
             public let allColumns: [any StructuredQueriesCore.QueryExpression]
             public static func photo(
@@ -2461,14 +2461,14 @@ extension SnapshotTests {
             ) -> Self {
               var allColumns: [any StructuredQueriesCore.QueryExpression] = []
               allColumns.append(contentsOf: photo._allColumns)
-              allColumns.append(contentsOf: Photo?(queryOutput: nil)._allColumns)
+              allColumns.append(contentsOf: String?(queryOutput: nil)._allColumns)
               return Self(allColumns: allColumns)
             }
             public static func note(
               _ note: some StructuredQueriesCore.QueryExpression<String>
             ) -> Self {
               var allColumns: [any StructuredQueriesCore.QueryExpression] = []
-              allColumns.append(contentsOf: String?(queryOutput: nil)._allColumns)
+              allColumns.append(contentsOf: Photo?(queryOutput: nil)._allColumns)
               allColumns.append(contentsOf: note._allColumns)
               return Self(allColumns: allColumns)
             }
@@ -2482,7 +2482,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Photo._columnWidth, String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Photo._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "posts"
@@ -2557,7 +2560,7 @@ extension SnapshotTests {
             }
           }
 
-          public struct Selection: StructuredQueriesCore.TableExpression {
+          public nonisolated struct Selection: StructuredQueriesCore.TableExpression {
             public typealias QueryValue = Post
             public let allColumns: [any StructuredQueriesCore.QueryExpression]
             public static func photo(
@@ -2565,14 +2568,14 @@ extension SnapshotTests {
             ) -> Self {
               var allColumns: [any StructuredQueriesCore.QueryExpression] = []
               allColumns.append(contentsOf: photo._allColumns)
-              allColumns.append(contentsOf: Photo?(queryOutput: nil)._allColumns)
+              allColumns.append(contentsOf: String?(queryOutput: nil)._allColumns)
               return Self(allColumns: allColumns)
             }
             public static func note(
               _ note: some StructuredQueriesCore.QueryExpression<String>
             ) -> Self {
               var allColumns: [any StructuredQueriesCore.QueryExpression] = []
-              allColumns.append(contentsOf: String?(queryOutput: nil)._allColumns)
+              allColumns.append(contentsOf: Photo?(queryOutput: nil)._allColumns)
               allColumns.append(contentsOf: note._allColumns)
               return Self(allColumns: allColumns)
             }
@@ -2586,7 +2589,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Photo._columnWidth, String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Photo._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "posts"
@@ -2657,7 +2663,7 @@ extension SnapshotTests {
             }
           }
 
-          public struct Selection: StructuredQueriesCore.TableExpression {
+          public nonisolated struct Selection: StructuredQueriesCore.TableExpression {
             public typealias QueryValue = Post
             public let allColumns: [any StructuredQueriesCore.QueryExpression]
             public static func photo(
@@ -2665,14 +2671,14 @@ extension SnapshotTests {
             ) -> Self {
               var allColumns: [any StructuredQueriesCore.QueryExpression] = []
               allColumns.append(contentsOf: photo._allColumns)
-              allColumns.append(contentsOf: Photo?(queryOutput: nil)._allColumns)
+              allColumns.append(contentsOf: String?(queryOutput: nil)._allColumns)
               return Self(allColumns: allColumns)
             }
             public static func note(
               _ note: some StructuredQueriesCore.QueryExpression<String>
             ) -> Self {
               var allColumns: [any StructuredQueriesCore.QueryExpression] = []
-              allColumns.append(contentsOf: String?(queryOutput: nil)._allColumns)
+              allColumns.append(contentsOf: Photo?(queryOutput: nil)._allColumns)
               allColumns.append(contentsOf: note._allColumns)
               return Self(allColumns: allColumns)
             }
@@ -2686,7 +2692,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Photo._columnWidth, String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Photo._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "posts"
@@ -2742,7 +2751,7 @@ extension SnapshotTests {
             }
           }
 
-          public struct Selection: StructuredQueriesCore.TableExpression {
+          public nonisolated struct Selection: StructuredQueriesCore.TableExpression {
             public typealias QueryValue = Post
             public let allColumns: [any StructuredQueriesCore.QueryExpression]
             public static func photo(
@@ -2750,14 +2759,14 @@ extension SnapshotTests {
             ) -> Self {
               var allColumns: [any StructuredQueriesCore.QueryExpression] = []
               allColumns.append(contentsOf: photo._allColumns)
-              allColumns.append(contentsOf: Photo?(queryOutput: nil)._allColumns)
+              allColumns.append(contentsOf: String?(queryOutput: nil)._allColumns)
               return Self(allColumns: allColumns)
             }
             public static func note(
               text note: some StructuredQueriesCore.QueryExpression<String>
             ) -> Self {
               var allColumns: [any StructuredQueriesCore.QueryExpression] = []
-              allColumns.append(contentsOf: String?(queryOutput: nil)._allColumns)
+              allColumns.append(contentsOf: Photo?(queryOutput: nil)._allColumns)
               allColumns.append(contentsOf: note._allColumns)
               return Self(allColumns: allColumns)
             }
@@ -2771,7 +2780,10 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Photo._columnWidth, String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Photo._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "posts"
@@ -2823,7 +2835,7 @@ extension SnapshotTests {
             }
           }
 
-          public struct Selection: StructuredQueriesCore.TableExpression {
+          public nonisolated struct Selection: StructuredQueriesCore.TableExpression {
             public typealias QueryValue = Post
             public let allColumns: [any StructuredQueriesCore.QueryExpression]
             public static func note(
@@ -2843,7 +2855,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [String._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += String._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "posts"
@@ -2893,7 +2907,7 @@ extension SnapshotTests {
             }
           }
 
-          public struct Selection: StructuredQueriesCore.TableExpression {
+          public nonisolated struct Selection: StructuredQueriesCore.TableExpression {
             public typealias QueryValue = Post
             public let allColumns: [any StructuredQueriesCore.QueryExpression]
             public static func timestamp(
@@ -2913,7 +2927,9 @@ extension SnapshotTests {
             TableColumns()
           }
           public nonisolated static var _columnWidth: Int {
-            [Date.UnixTimeRepresentation._columnWidth].reduce(0, +)
+            var columnWidth = 0
+            columnWidth += Date.UnixTimeRepresentation._columnWidth
+            return columnWidth
           }
           public nonisolated static var tableName: String {
             "posts"

--- a/Tests/StructuredQueriesTests/EnumTableTests.swift
+++ b/Tests/StructuredQueriesTests/EnumTableTests.swift
@@ -342,6 +342,44 @@
           """
         }
       }
+
+      @Test func selection() {
+        assertQuery(
+          Values(
+            Attachment.Kind.Selection.note("Hello, world!")
+          )
+        ) {
+          """
+          SELECT NULL AS "link", 'Hello, world!' AS "note", NULL AS "videoURL", NULL AS "videoKind", NULL AS "imageCaption", NULL AS "imageURL"
+          """
+        } results: {
+          """
+          ┌───────────────────────────────────────┐
+          │ Attachment.Kind.note("Hello, world!") │
+          └───────────────────────────────────────┘
+          """
+        }
+        assertQuery(
+          Values(
+            Attachment.Kind.Selection.image(Attachment.Image(caption: "Blob", url: URL(string: "https://pointfree.co")!))
+          )
+        ) {
+          """
+          SELECT NULL AS "link", NULL AS "note", NULL AS "videoURL", NULL AS "videoKind", 'Blob', 'https://pointfree.co' AS "imageCaption"
+          """
+        } results: {
+          """
+          ┌────────────────────────────────────┐
+          │ Attachment.Kind.image(             │
+          │   Attachment.Image(                │
+          │     caption: "Blob",               │
+          │     url: URL(https://pointfree.co) │
+          │   )                                │
+          │ )                                  │
+          └────────────────────────────────────┘
+          """
+        }
+      }
     }
   }
 


### PR DESCRIPTION
We were outputting the wrong types for query-building code.