### PR TITLE
Fix unconditional nonisolated.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
       }
     },
     {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
+        "version" : "1.7.2"
+      }
+    },
+    {
       "identity" : "swift-clocks",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
@@ -89,6 +98,15 @@
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "swift-tagged",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-tagged",
+      "state" : {
+        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
+        "version" : "0.10.0"
       }
     },
     {

--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -1474,7 +1474,7 @@ extension TableMacro: MemberMacro {
       }
       """,
       """
-      public nonisolated struct Selection: \(moduleName).TableExpression {
+      public \(nonisolated)struct Selection: \(moduleName).TableExpression {
       public typealias QueryValue = \(type.trimmed)
       public let allColumns: [any \(moduleName).QueryExpression]
       \(selectionInitializers, separator: "\n")


### PR DESCRIPTION
Forgot to interpolate `nonisolated` in part of our macro which prevents this code from compiling on Swift <6.1.