### PR TITLE
Update generated property to let

### DIFF
--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/DefiningYourSchema.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/DefiningYourSchema.md
@@ -479,7 +479,7 @@ struct Event {
   var duration: TimeInterval
 
   @Column(generated: .stored)
-  var endAt: Date
+  let endAt: Date
 }
 ```
 


### PR DESCRIPTION
The @Table macro requires that generated columns are declared as lets. Updated documentation to reflect that. 