### PR TITLE
Disambiguate selection column aliases

### DIFF
--- a/Sources/StructuredQueriesCore/TableExpression.swift
+++ b/Sources/StructuredQueriesCore/TableExpression.swift
@@ -9,8 +9,26 @@ public protocol TableExpression<QueryValue>: QueryExpression where QueryValue: T
 extension TableExpression {
   public var queryFragment: QueryFragment {
     if _isSelecting {
-      return zip(allColumns, QueryValue.TableColumns.allColumns)
-        .map { "\($0) AS \(quote: $1.name)" }
+      let columnNames = QueryValue.TableColumns.allColumns.map(\.name)
+      var columnNameCounts: [String: Int] = [:]
+      for name in columnNames {
+        columnNameCounts[name, default: 0] += 1
+      }
+      var columnNamesCount: [String: Int] = [:]
+      let aliases = columnNames.map { name in
+        var alias =
+          QueryValue.self is any _Selection.Type
+          ? "\(QueryValue.tableAlias ?? QueryValue.tableName)_\(name)"
+          : name
+        if columnNameCounts[name, default: 0] > 1 {
+          let count = (columnNamesCount[name] ?? 0) + 1
+          columnNamesCount[name] = count
+          alias = "\(alias)_\(count)"
+        }
+        return alias
+      }
+      return zip(allColumns, aliases)
+        .map { "\($0) AS \(quote: $1)" }
         .joined(separator: ", ")
     } else {
       return allColumns.map(\.queryFragment).joined(separator: ", ")

--- a/Tests/StructuredQueriesTests/JSONFunctionsTests.swift
+++ b/Tests/StructuredQueriesTests/JSONFunctionsTests.swift
@@ -142,7 +142,7 @@ extension SnapshotTests {
           .limit(2)
       ) {
         """
-        SELECT "users"."id" AS "id", "users"."name" AS "name", "reminders"."id" AS "id", "reminders"."assignedUserID" AS "assignedUserID", "reminders"."dueDate" AS "dueDate", "reminders"."isCompleted" AS "isCompleted", "reminders"."isFlagged" AS "isFlagged", "reminders"."notes" AS "notes", "reminders"."priority" AS "priority", "reminders"."remindersListID" AS "remindersListID", "reminders"."title" AS "title", "reminders"."updatedAt" AS "updatedAt", json_group_array(CASE WHEN ("tags"."rowid") IS NOT (NULL) THEN json_object('id', json_quote("tags"."id"), 'title', json_quote("tags"."title")) END) FILTER (WHERE ("tags"."rowid") IS NOT (NULL)) AS "tags"
+        SELECT "users"."id" AS "id_1", "users"."name" AS "name", "reminders"."id" AS "id_2", "reminders"."assignedUserID" AS "assignedUserID", "reminders"."dueDate" AS "dueDate", "reminders"."isCompleted" AS "isCompleted", "reminders"."isFlagged" AS "isFlagged", "reminders"."notes" AS "notes", "reminders"."priority" AS "priority", "reminders"."remindersListID" AS "remindersListID", "reminders"."title" AS "title", "reminders"."updatedAt" AS "updatedAt", json_group_array(CASE WHEN ("tags"."rowid") IS NOT (NULL) THEN json_object('id', json_quote("tags"."id"), 'title', json_quote("tags"."title")) END) FILTER (WHERE ("tags"."rowid") IS NOT (NULL)) AS "tags"
         FROM "reminders"
         LEFT JOIN "remindersTags" ON ("reminders"."id") = ("remindersTags"."reminderID")
         LEFT JOIN "tags" ON ("remindersTags"."tagID") = ("tags"."id")
@@ -517,7 +517,7 @@ extension SnapshotTests {
           .select { GroupedItem.Columns(bucket: $0.bucket, items: $0.jsonGroupArray()) }
       ) {
         """
-        SELECT "items"."bucket" AS "bucket", json_group_array(json_object('bucket', json_quote("items"."bucket"), 'value', json_quote("items"."value"))) AS "items"
+        SELECT "items"."bucket" AS "groupedItems_bucket", json_group_array(json_object('bucket', json_quote("items"."bucket"), 'value', json_quote("items"."value"))) AS "groupedItems_items"
         FROM "items"
         GROUP BY "items"."bucket"
         """

--- a/Tests/StructuredQueriesTests/NestedTests.swift
+++ b/Tests/StructuredQueriesTests/NestedTests.swift
@@ -503,7 +503,7 @@ extension SnapshotTests {
           }
       ) {
         """
-        SELECT "remindersLists"."id" AS "id", "remindersLists"."color" AS "color", "remindersLists"."title" AS "title", "remindersLists"."position" AS "position", count("reminders"."id") AS "remindersCount"
+        SELECT "remindersLists"."id" AS "remindersListAndReminderCountPayloads_id", "remindersLists"."color" AS "remindersListAndReminderCountPayloads_color", "remindersLists"."title" AS "remindersListAndReminderCountPayloads_title", "remindersLists"."position" AS "remindersListAndReminderCountPayloads_position", count("reminders"."id") AS "remindersListAndReminderCountPayloads_remindersCount"
         FROM "remindersLists"
         JOIN "reminders" ON ("remindersLists"."id") = ("reminders"."remindersListID")
         WHERE color > 0

--- a/Tests/StructuredQueriesTests/SelectionTests.swift
+++ b/Tests/StructuredQueriesTests/SelectionTests.swift
@@ -19,7 +19,7 @@ extension SnapshotTests {
           }
       ) {
         """
-        SELECT "remindersLists"."id" AS "id", "remindersLists"."color" AS "color", "remindersLists"."title" AS "title", "remindersLists"."position" AS "position", count("reminders"."id") AS "remindersCount"
+        SELECT "remindersLists"."id" AS "remindersListAndReminderCounts_id", "remindersLists"."color" AS "remindersListAndReminderCounts_color", "remindersLists"."title" AS "remindersListAndReminderCounts_title", "remindersLists"."position" AS "remindersListAndReminderCounts_position", count("reminders"."id") AS "remindersListAndReminderCounts_remindersCount"
         FROM "remindersLists"
         JOIN "reminders" ON ("remindersLists"."id") = ("reminders"."remindersListID")
         GROUP BY "remindersLists"."id"
@@ -158,7 +158,7 @@ extension SnapshotTests {
           }
       ) {
         """
-        SELECT "reminders"."title" AS "reminderTitle", "users"."name" AS "assignedUserName"
+        SELECT "reminders"."title" AS "reminderTitleAndAssignedUserNames_reminderTitle", "users"."name" AS "reminderTitleAndAssignedUserNames_assignedUserName"
         FROM "reminders"
         LEFT JOIN "users" ON ("reminders"."assignedUserID") IS ("users"."id")
         LIMIT 2
@@ -187,7 +187,7 @@ extension SnapshotTests {
         }
       ) {
         """
-        SELECT "reminders"."dueDate" AS "date"
+        SELECT "reminders"."dueDate" AS "reminderDates_date"
         FROM "reminders"
         """
       } results: {
@@ -219,7 +219,7 @@ extension SnapshotTests {
         }
       ) {
         """
-        SELECT count("reminders"."id") FILTER (WHERE "reminders"."isCompleted") AS "completedCount", count("reminders"."id") FILTER (WHERE "reminders"."isFlagged") AS "flaggedCount", count("reminders"."id") AS "totalCount"
+        SELECT count("reminders"."id") FILTER (WHERE "reminders"."isCompleted") AS "statses_completedCount", count("reminders"."id") FILTER (WHERE "reminders"."isFlagged") AS "statses_flaggedCount", count("reminders"."id") AS "statses_totalCount"
         FROM "reminders"
         """
       } results: {
@@ -252,7 +252,7 @@ extension SnapshotTests {
           }
       ) {
         """
-        SELECT "rLs"."id" AS "id", "rLs"."color" AS "color", "rLs"."title" AS "title", "rLs"."position" AS "position", count("reminders"."id") AS "remindersCount"
+        SELECT "rLs"."id" AS "remindersListAliasAndReminderCounts_id", "rLs"."color" AS "remindersListAliasAndReminderCounts_color", "rLs"."title" AS "remindersListAliasAndReminderCounts_title", "rLs"."position" AS "remindersListAliasAndReminderCounts_position", count("reminders"."id") AS "remindersListAliasAndReminderCounts_remindersCount"
         FROM "remindersLists" AS "rLs"
         JOIN "reminders" ON ("rLs"."id") = ("reminders"."remindersListID")
         GROUP BY "rLs"."id"
@@ -300,7 +300,7 @@ extension SnapshotTests {
           }
       ) {
         """
-        SELECT "rLs"."id" AS "id", "rLs"."color" AS "color", "rLs"."title" AS "title", "rLs"."position" AS "position", count("reminders"."id") AS "remindersCount"
+        SELECT "rLs"."id" AS "optionalRemindersListAliasAndReminderCounts_id", "rLs"."color" AS "optionalRemindersListAliasAndReminderCounts_color", "rLs"."title" AS "optionalRemindersListAliasAndReminderCounts_title", "rLs"."position" AS "optionalRemindersListAliasAndReminderCounts_position", count("reminders"."id") AS "optionalRemindersListAliasAndReminderCounts_remindersCount"
         FROM "reminders"
         LEFT JOIN "remindersLists" AS "rLs" ON ("reminders"."remindersListID") = ("rLs"."id")
         """
@@ -317,6 +317,128 @@ extension SnapshotTests {
         │   remindersCount: 10                        │
         │ )                                           │
         └─────────────────────────────────────────────┘
+        """
+      }
+    }
+
+    @Test func duplicateSelectionColumnNames() {
+      assertQuery(
+        Reminder.select {
+          (IDSelection.Columns(id: $0.id), AnotherIDSelection.Columns(id: $0.id))
+        }
+      ) {
+        """
+        SELECT "reminders"."id" AS "idSelections_id", "reminders"."id" AS "anotherIDSelections_id"
+        FROM "reminders"
+        """
+      } results: {
+        """
+        ┌─────────────────────┬────────────────────────────┐
+        │ IDSelection(id: 1)  │ AnotherIDSelection(id: 1)  │
+        │ IDSelection(id: 2)  │ AnotherIDSelection(id: 2)  │
+        │ IDSelection(id: 3)  │ AnotherIDSelection(id: 3)  │
+        │ IDSelection(id: 4)  │ AnotherIDSelection(id: 4)  │
+        │ IDSelection(id: 5)  │ AnotherIDSelection(id: 5)  │
+        │ IDSelection(id: 6)  │ AnotherIDSelection(id: 6)  │
+        │ IDSelection(id: 7)  │ AnotherIDSelection(id: 7)  │
+        │ IDSelection(id: 8)  │ AnotherIDSelection(id: 8)  │
+        │ IDSelection(id: 9)  │ AnotherIDSelection(id: 9)  │
+        │ IDSelection(id: 10) │ AnotherIDSelection(id: 10) │
+        └─────────────────────┴────────────────────────────┘
+        """
+      }
+    }
+
+    @Test func duplicateColumnNamesWithinSelectionWithColumnGroup() {
+      assertQuery(
+        RemindersList.select {
+          SelectionWithColumnGroupAndID.Columns(id: $0.id, remindersList: $0)
+        }
+      ) {
+        """
+        SELECT "remindersLists"."id" AS "selectionWithColumnGroupAndIDs_id_1", "remindersLists"."id" AS "selectionWithColumnGroupAndIDs_id_2", "remindersLists"."color" AS "selectionWithColumnGroupAndIDs_color", "remindersLists"."title" AS "selectionWithColumnGroupAndIDs_title", "remindersLists"."position" AS "selectionWithColumnGroupAndIDs_position"
+        FROM "remindersLists"
+        """
+      } results: {
+        """
+        ┌─────────────────────────────────┐
+        │ SelectionWithColumnGroupAndID(  │
+        │   id: 1,                        │
+        │   remindersList: RemindersList( │
+        │     id: 1,                      │
+        │     color: 4889071,             │
+        │     title: "Personal",          │
+        │     position: 0                 │
+        │   )                             │
+        │ )                               │
+        ├─────────────────────────────────┤
+        │ SelectionWithColumnGroupAndID(  │
+        │   id: 2,                        │
+        │   remindersList: RemindersList( │
+        │     id: 2,                      │
+        │     color: 15567157,            │
+        │     title: "Family",            │
+        │     position: 0                 │
+        │   )                             │
+        │ )                               │
+        ├─────────────────────────────────┤
+        │ SelectionWithColumnGroupAndID(  │
+        │   id: 3,                        │
+        │   remindersList: RemindersList( │
+        │     id: 3,                      │
+        │     color: 11689427,            │
+        │     title: "Business",          │
+        │     position: 0                 │
+        │   )                             │
+        │ )                               │
+        └─────────────────────────────────┘
+        """
+      }
+    }
+
+    @Test func duplicateColumnNamesWithinSelectionWithColumnGroupAlias() {
+      assertQuery(
+        RemindersList.as(RL.self).select {
+          SelectionWithColumnGroupAliasAndID.Columns(id: $0.id, remindersList: $0)
+        }
+      ) {
+        """
+        SELECT "rLs"."id" AS "selectionWithColumnGroupAliasAndIDs_id_1", "rLs"."id" AS "selectionWithColumnGroupAliasAndIDs_id_2", "rLs"."color" AS "selectionWithColumnGroupAliasAndIDs_color", "rLs"."title" AS "selectionWithColumnGroupAliasAndIDs_title", "rLs"."position" AS "selectionWithColumnGroupAliasAndIDs_position"
+        FROM "remindersLists" AS "rLs"
+        """
+      } results: {
+        """
+        ┌─────────────────────────────────────┐
+        │ SelectionWithColumnGroupAliasAndID( │
+        │   id: 1,                            │
+        │   remindersList: RemindersList(     │
+        │     id: 1,                          │
+        │     color: 4889071,                 │
+        │     title: "Personal",              │
+        │     position: 0                     │
+        │   )                                 │
+        │ )                                   │
+        ├─────────────────────────────────────┤
+        │ SelectionWithColumnGroupAliasAndID( │
+        │   id: 2,                            │
+        │   remindersList: RemindersList(     │
+        │     id: 2,                          │
+        │     color: 15567157,                │
+        │     title: "Family",                │
+        │     position: 0                     │
+        │   )                                 │
+        │ )                                   │
+        ├─────────────────────────────────────┤
+        │ SelectionWithColumnGroupAliasAndID( │
+        │   id: 3,                            │
+        │   remindersList: RemindersList(     │
+        │     id: 3,                          │
+        │     color: 11689427,                │
+        │     title: "Business",              │
+        │     position: 0                     │
+        │   )                                 │
+        │ )                                   │
+        └─────────────────────────────────────┘
         """
       }
     }
@@ -361,4 +483,27 @@ struct Stats {
   let completedCount: Int
   let flaggedCount: Int
   let totalCount: Int
+}
+
+@Selection
+struct IDSelection {
+  let id: Int
+}
+
+@Selection
+struct AnotherIDSelection {
+  let id: Int
+}
+
+@Selection
+struct SelectionWithColumnGroupAndID {
+  let id: Int
+  let remindersList: RemindersList
+}
+
+@Selection
+struct SelectionWithColumnGroupAliasAndID {
+  let id: Int
+  @Columns(as: TableAlias<RemindersList, RL>.self)
+  let remindersList: RemindersList
 }


### PR DESCRIPTION
Currently, database views and CTEs can introduce ambiguous columns in the SELECT portion of the query. We can disambiguate the alias names by prefixing table names where we can, and otherwise suffixing the column with an incrementing counter.