### PR TITLE
Change Boolean binding mapping

### DIFF
--- a/Sources/StructuredQueriesCore/QueryBindable.swift
+++ b/Sources/StructuredQueriesCore/QueryBindable.swift
@@ -20,7 +20,7 @@ extension [UInt8]: QueryBindable, QueryExpression {
 }
 
 extension Bool: QueryBindable {
-  public var queryBinding: QueryBinding { .int(self ? 1 : 0) }
+  public var queryBinding: QueryBinding { .bool(self) }
 }
 
 extension Double: QueryBindable {

--- a/Sources/StructuredQueriesSQLiteCore/Triggers.swift
+++ b/Sources/StructuredQueriesSQLiteCore/Triggers.swift
@@ -149,7 +149,7 @@ public struct TemporaryTrigger<On: Table>: Sendable, Statement {
     public static func insert(
       @QueryFragmentBuilder<any Statement>
       forEachRow perform: (_ new: New) -> [QueryFragment],
-      when condition: ((_ new: New) -> any QueryExpression<Bool>)? = nil,
+      when condition: ((_ new: New) -> any QueryExpression<Bool>)? = nil
     ) -> Self {
       Self(
         kind: .insert(operations: perform(On.as(_New.self).columns)),


### PR DESCRIPTION
Currently nothing us using the actual `.bool` data type, booleans map to `0` or `1`.

This updates that.

Note: I am only 6.0 locally so a lot of the macro tests fail due to `nonisolated` mismatches in the output