### PR TITLE
Support swift-syntax 605

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -57,7 +57,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
     .package(url: "https://github.com/pointfreeco/swift-tagged", from: "0.10.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.2"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"603.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"605.0.0"),
   ],
   targets: [
     .target(

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -39,7 +39,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.3"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.2"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"603.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"605.0.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Bumps swift-syntax upper bound from 603 to 605 to support 603.x and 604.x prereleases.
https://github.com/search?q=org%3Apointfreeco+https%3A%2F%2Fgithub.com%2Fswiftlang%2Fswift-syntax+603.0.0&type=code

- same: https://github.com/pointfreeco/swift-dependencies/pull/416