### PR TITLE
Fix method call to use 'self.where' instead of 'Self.where'

### DIFF
--- a/Sources/StructuredQueriesCore/PrimaryKeyed.swift
+++ b/Sources/StructuredQueriesCore/PrimaryKeyed.swift
@@ -170,7 +170,7 @@ extension Where where From: TableDraft {
   public func find(
     _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryKey>>
   ) -> Self {
-    Self.where { $0.primaryKey.in(primaryKeys) }
+    self.where { $0.primaryKey.in(primaryKeys) }
   }
 }
 

--- a/Sources/StructuredQueriesCore/PrimaryKeyed.swift
+++ b/Sources/StructuredQueriesCore/PrimaryKeyed.swift
@@ -148,7 +148,7 @@ extension Where where From: PrimaryKeyedTable {
   public func find(
     _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryKey>>
   ) -> Self {
-    Self.where { $0.primaryKey.in(primaryKeys) }
+    self.where { $0.primaryKey.in(primaryKeys) }
   }
 }
 

--- a/Tests/StructuredQueriesTests/TableTests.swift
+++ b/Tests/StructuredQueriesTests/TableTests.swift
@@ -550,6 +550,41 @@ extension SnapshotTests {
         }
       }
 
+      @Test func unscopedFind() throws {
+        assertQuery(Row.unscoped.find(2)) {
+          """
+          SELECT "rows"."id", "rows"."isDeleted"
+          FROM "rows"
+          WHERE (("rows"."id") IN ((2)))
+          """
+        } results: {
+          """
+          ┌────────────────────────────────────────────┐
+          │ SnapshotTests.TableTests.DefaultWhere.Row( │
+          │   id: 2,                                   │
+          │   isDeleted: true                          │
+          │ )                                          │
+          └────────────────────────────────────────────┘
+          """
+        }
+        assertQuery(Row.Draft.unscoped.find(2)) {
+          """
+          SELECT "rows"."id", "rows"."isDeleted"
+          FROM "rows"
+          WHERE (("rows"."id") IN ((2)))
+          """
+        } results: {
+          """
+          ┌──────────────────────────────────────────────────┐
+          │ SnapshotTests.TableTests.DefaultWhere.Row.Draft( │
+          │   id: 2,                                         │
+          │   isDeleted: true                                │
+          │ )                                                │
+          └──────────────────────────────────────────────────┘
+          """
+        }
+      }
+
       #if compiler(>=6.1)
         @Test func rescope() {
           assertQuery(Row.unscoped.all) {


### PR DESCRIPTION
Every other instance method on `Where` (where, and, or, not) uses `self` to preserve state. `Update.find` and `Delete.find` also use `self.where`. Only `Where.find` breaks the pattern by calling `Self.where`, which creates a fresh `Where` with default scope, discarding both the unscoped state and any existing predicates.