### PR TITLE
Computed primary keys

### DIFF
--- a/Sources/StructuredQueries/Macros.swift
+++ b/Sources/StructuredQueries/Macros.swift
@@ -189,3 +189,7 @@ public macro sql(
   as queryValueType: Any.Type = Any.self
 ) -> SQLQueryExpression<Any> =
   #externalMacro(module: "StructuredQueriesMacros", type: "SQLMacro")
+
+@attached(accessor, names: named(get))
+public macro _PrimaryKeyDefault() =
+  #externalMacro(module: "StructuredQueriesMacros", type: "PrimaryKeyDefaultMacro")

--- a/Sources/StructuredQueriesMacros/Plugin.swift
+++ b/Sources/StructuredQueriesMacros/Plugin.swift
@@ -8,6 +8,7 @@ struct StructuredQueriesPlugin: CompilerPlugin {
     ColumnMacro.self,
     ColumnsMacro.self,
     EphemeralMacro.self,
+    PrimaryKeyDefaultMacro.self,
     SQLMacro.self,
     TableMacro.self,
   ]

--- a/Sources/StructuredQueriesMacros/PrimaryKeyDefaultMacro.swift
+++ b/Sources/StructuredQueriesMacros/PrimaryKeyDefaultMacro.swift
@@ -1,0 +1,39 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public enum PrimaryKeyDefaultMacro {}
+
+extension PrimaryKeyDefaultMacro: AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    guard
+      let property = declaration.as(VariableDeclSyntax.self),
+      let binding = property.bindings.first,
+      let initializer = binding.initializer?.value.as(FunctionCallExprSyntax.self),
+      let keyPathArgument = initializer.arguments.first(where: { $0.label?.text == "keyPath" }),
+      let keyPath = keyPathArgument.expression.as(KeyPathExprSyntax.self),
+      let component = keyPath.components.last?.component.as(
+        KeyPathPropertyComponentSyntax.self
+      )
+    else {
+      context.diagnose(
+        Diagnostic(
+          node: node,
+          message: MacroExpansionErrorMessage(
+            """
+            '@_PrimaryKeyDefault' must be applied to a column property initialized with a \
+            'keyPath' argument
+            """
+          )
+        )
+      )
+      return []
+    }
+    return ["get { \(component.declName.baseName.trimmed) }"]
+  }
+}

--- a/Sources/StructuredQueriesMacros/PrimaryKeyDefaultMacro.swift
+++ b/Sources/StructuredQueriesMacros/PrimaryKeyDefaultMacro.swift
@@ -1,7 +1,7 @@
 import SwiftDiagnostics
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 public enum PrimaryKeyDefaultMacro {}
 

--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -390,7 +390,8 @@ extension TableMacro: ExtensionMacro {
         func appendColumnProperty(primaryKey: Bool = false) {
           columnsProperties.append(
             """
-            public let \(primaryKey ? "primaryKey" : identifier) = \
+            \(raw: primaryKey ? "@StructuredQueries._PrimaryKeyDefault public var" : "public let") \
+            \(primaryKey ? "primaryKey" : identifier) = \
             \(moduleName).\(raw: tableColumnType)<\
             QueryValue, \
             \(raw: columnQueryValueType?.trimmedDescription ?? "_")\
@@ -1082,7 +1083,8 @@ extension TableMacro: MemberMacro {
         func appendColumnProperty(primaryKey: Bool = false) {
           columnsProperties.append(
             """
-            public let \(primaryKey ? "primaryKey" : identifier) = \
+            \(raw: primaryKey ? "@StructuredQueries._PrimaryKeyDefault public var" : "public let") \
+            \(primaryKey ? "primaryKey" : identifier) = \
             \(moduleName).\(raw: tableColumnType)<\
             QueryValue, \
             \(raw: columnQueryValueType?.trimmedDescription ?? "_")\

--- a/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
@@ -210,7 +210,7 @@ extension SnapshotTests {
             public typealias QueryValue = User
             public typealias PrimaryKey = Int
             public let id = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
             public let email = StructuredQueriesCore._TableColumn<QueryValue, String?>.for("email", keyPath: \QueryValue.email, default: "")
             public let age = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("age", keyPath: \QueryValue.age)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
@@ -1076,7 +1076,7 @@ extension SnapshotTests {
             public typealias QueryValue = User
             public typealias PrimaryKey = Int
             public let id = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
             public let name = StructuredQueriesCore._TableColumn<QueryValue, String>.for("name", keyPath: \QueryValue.name)
             public let generated = StructuredQueriesCore.GeneratedColumn<QueryValue, Int>("generated", keyPath: \QueryValue.generated)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
@@ -1601,7 +1601,7 @@ extension SnapshotTests {
             public typealias QueryValue = User
             public typealias PrimaryKey = ID<User, UUID.BytesRepresentation>
             public let id = StructuredQueriesCore.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>>("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>>("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>>("id", keyPath: \QueryValue.id)
             public let referrerID = StructuredQueriesCore.TableColumn<QueryValue, ID<User, UUID.BytesRepresentation>?>("referrerID", keyPath: \QueryValue.referrerID, default: nil)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
@@ -1830,7 +1830,7 @@ extension SnapshotTests {
             public typealias QueryValue = SyncUp
             public typealias PrimaryKey = Int
             public let id = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
             public let name = StructuredQueriesCore._TableColumn<QueryValue, String>.for("name", keyPath: \QueryValue.name)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
@@ -2009,7 +2009,7 @@ extension SnapshotTests {
             public typealias QueryValue = SyncUp
             public typealias PrimaryKey = Int
             public let id = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
             public let seconds = StructuredQueriesCore._TableColumn<QueryValue, <#Type#>>.for("seconds", keyPath: \QueryValue.seconds, default: 60 * 5)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
@@ -2167,7 +2167,7 @@ extension SnapshotTests {
             public typealias QueryValue = RemindersList
             public typealias PrimaryKey = Int
             public let id = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
             public let color = StructuredQueriesCore.TableColumn<QueryValue, Color.HexRepresentation>("color", keyPath: \QueryValue.color, default: Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255))
             public let name = StructuredQueriesCore._TableColumn<QueryValue, Swift.String>.for("name", keyPath: \QueryValue.name, default: "")
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
@@ -3060,7 +3060,7 @@ extension SnapshotTests {
             public typealias QueryValue = Foo
             public typealias PrimaryKey = Int
             public let id = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
               allColumns.append(contentsOf: QueryValue.columns.id._allColumns)
@@ -3314,7 +3314,7 @@ extension SnapshotTests {
             public typealias QueryValue = Foo
             public typealias PrimaryKey = Int
             public let id = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
             public let name = StructuredQueriesCore._TableColumn<QueryValue, String>.for("name", keyPath: \QueryValue.name)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
@@ -3482,7 +3482,7 @@ extension SnapshotTests {
             public typealias QueryValue = Reminder
             public typealias PrimaryKey = Int
             public let id = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int>.for("id", keyPath: \QueryValue.id)
             public let title = StructuredQueriesCore._TableColumn<QueryValue, Swift.String>.for("title", keyPath: \QueryValue.title, default: "")
             public let date = StructuredQueriesCore.TableColumn<QueryValue, Date.UnixTimeRepresentation?>("date", keyPath: \QueryValue.date, default: nil)
             public let priority = StructuredQueriesCore._TableColumn<QueryValue, Priority?>.for("priority", keyPath: \QueryValue.priority, default: nil)
@@ -3672,7 +3672,7 @@ extension SnapshotTests {
             public typealias QueryValue = Reminder
             public typealias PrimaryKey = UUID.BytesRepresentation
             public let id = StructuredQueriesCore.TableColumn<QueryValue, UUID.BytesRepresentation>("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore.TableColumn<QueryValue, UUID.BytesRepresentation>("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore.TableColumn<QueryValue, UUID.BytesRepresentation>("id", keyPath: \QueryValue.id)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
               allColumns.append(contentsOf: QueryValue.columns.id._allColumns)
@@ -3880,7 +3880,7 @@ extension SnapshotTests {
             public typealias QueryValue = Reminder
             public typealias PrimaryKey = Int?
             public let id = StructuredQueriesCore._TableColumn<QueryValue, Int?>.for("id", keyPath: \QueryValue.id, default: nil)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int?>.for("id", keyPath: \QueryValue.id, default: nil)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, Int?>.for("id", keyPath: \QueryValue.id, default: nil)
             public let title = StructuredQueriesCore._TableColumn<QueryValue, Swift.String>.for("title", keyPath: \QueryValue.title, default: "")
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
@@ -4032,7 +4032,7 @@ extension SnapshotTests {
             public typealias QueryValue = Row
             public typealias PrimaryKey = UUID
             public let id = StructuredQueriesCore._TableColumn<QueryValue, UUID>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, UUID>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, UUID>.for("id", keyPath: \QueryValue.id)
             public let timestamps = StructuredQueriesCore.ColumnGroup<QueryValue, Timestamps>(keyPath: \QueryValue.timestamps)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
@@ -4194,7 +4194,7 @@ extension SnapshotTests {
             public typealias QueryValue = ReminderTag
             public typealias PrimaryKey = ReminderTagID
             public let id = StructuredQueriesCore.ColumnGroup<QueryValue, ReminderTagID>(keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore.ColumnGroup<QueryValue, ReminderTagID>(keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore.ColumnGroup<QueryValue, ReminderTagID>(keyPath: \QueryValue.id)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
               allColumns.append(contentsOf: QueryValue.columns.id._allColumns)
@@ -4334,7 +4334,7 @@ extension SnapshotTests {
             public typealias QueryValue = ReminderWithList
             public typealias PrimaryKey = Reminder.ID
             public let reminderID = StructuredQueriesCore.TableColumn<QueryValue, Reminder.ID>("reminderID", keyPath: \QueryValue.reminderID)
-            public let primaryKey = StructuredQueriesCore.TableColumn<QueryValue, Reminder.ID>("reminderID", keyPath: \QueryValue.reminderID)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore.TableColumn<QueryValue, Reminder.ID>("reminderID", keyPath: \QueryValue.reminderID)
             public let reminderTitle = StructuredQueriesCore._TableColumn<QueryValue, String>.for("reminderTitle", keyPath: \QueryValue.reminderTitle)
             public let remindersListTitle = StructuredQueriesCore._TableColumn<QueryValue, String>.for("remindersListTitle", keyPath: \QueryValue.remindersListTitle)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
@@ -4523,7 +4523,7 @@ extension SnapshotTests {
             public typealias QueryValue = Metadata
             public typealias PrimaryKey = MetadataID
             public let id = StructuredQueriesCore._TableColumn<QueryValue, MetadataID>.for("id", keyPath: \QueryValue.id)
-            public let primaryKey = StructuredQueriesCore._TableColumn<QueryValue, MetadataID>.for("id", keyPath: \QueryValue.id)
+            @StructuredQueries._PrimaryKeyDefault public var primaryKey = StructuredQueriesCore._TableColumn<QueryValue, MetadataID>.for("id", keyPath: \QueryValue.id)
             public let userModificationDate = StructuredQueriesCore._TableColumn<QueryValue, Date>.for("userModificationDate", keyPath: \QueryValue.userModificationDate)
             public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
               var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []


### PR DESCRIPTION
Currently, StructuredQueries generates `TableColumnes.primaryKey` as a `let` property just like every other column, even though it's technically an alias to another column.

We use `let` declarations for columns to maximize how many can be generated, _e.g._ for properties lacking type annotations that use default value inference, instead. But not only does that seem like a rare situation when it comes to primary keys, it's also not totally necessary.

However, in this case we can have our cake and eat it too: because `primaryKey` can be a computed property, we can use a secondary macro to generate the property with inference. This uses a trick employed by the `@Entry` macro (which we recently employed in ComposableArchitecture 2.0).

While this is improvement is general (`\.id == \.primaryKey → true`), it also works around a Swift compiler regression in Swift 6.4 that is causing downstream library code in SQLiteData to fail to compile.