### PR TITLE
Use public import for Tagged module

### DIFF
--- a/Sources/StructuredQueriesCore/Traits/Tagged.swift
+++ b/Sources/StructuredQueriesCore/Traits/Tagged.swift
@@ -1,5 +1,5 @@
 #if StructuredQueriesTagged
-  import Tagged
+  public import Tagged
 
   extension Tagged: _OptionalPromotable where RawValue: _OptionalPromotable {}
 

--- a/Sources/StructuredQueriesSQLiteCore/Cast.swift
+++ b/Sources/StructuredQueriesSQLiteCore/Cast.swift
@@ -108,7 +108,7 @@ extension _CodableJSONRepresentation: SQLiteType {
 }
 
 #if StructuredQueriesTagged
-  import Tagged
+  public import Tagged
 
   extension Tagged: SQLiteType where RawValue: SQLiteType {
     public static var typeAffinity: SQLiteTypeAffinity {


### PR DESCRIPTION
Make Tagged imports public in StructuredQueriesCore and StructuredQueriesSQLiteCore to re-export the module to downstream consumers.

Fixes #292 