### PR TITLE
Rename `CasePaths` and `Tagged` traits

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,12 +41,22 @@ let package = Package(
   ],
   traits: [
     .trait(
-      name: "StructuredQueriesCasePaths",
+      name: "CasePaths",
       description: "Introduce enum table support to StructuredQueries."
     ),
     .trait(
-      name: "StructuredQueriesTagged",
+      name: "Tagged",
       description: "Introduce StructuredQueries conformances to the swift-tagged package."
+    ),
+    .trait(
+      name: "StructuredQueriesCasePaths",
+      description: "A deprecated alias for the 'CasePaths' trait.",
+      enabledTraits: ["CasePaths"]
+    ),
+    .trait(
+      name: "StructuredQueriesTagged",
+      description: "A deprecated alias for the 'Tagged' trait.",
+      enabledTraits: ["Tagged"]
     ),
   ],
   dependencies: [
@@ -74,12 +84,12 @@ let package = Package(
         .product(
           name: "CasePaths",
           package: "swift-case-paths",
-          condition: .when(traits: ["StructuredQueriesCasePaths"])
+          condition: .when(traits: ["CasePaths"])
         ),
         .product(
           name: "Tagged",
           package: "swift-tagged",
-          condition: .when(traits: ["StructuredQueriesTagged"])
+          condition: .when(traits: ["Tagged"])
         ),
       ],
       exclude: ["Symbolic Links/README.md"]
@@ -161,8 +171,8 @@ if ProcessInfo.processInfo.environment["SPI_GENERATE_DOCS"] != nil  // || true  
   package.traits.insert(
     .default(
       enabledTraits: [
-        "StructuredQueriesCasePaths",
-        "StructuredQueriesTagged",
+        "CasePaths",
+        "Tagged",
       ]
     )
   )

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ it's as simple as adding it to your `Package.swift`:
 
 ``` swift
 dependencies: [
-  .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.22.0"),
+  .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.32.0"),
 ]
 ```
 
@@ -233,10 +233,10 @@ And then adding the product to any target that needs access to the library:
 If you are on Swift 6.1 or greater, you can enable package traits that extend the library with
 support for other libraries:
 
-  * `StructuredQueriesCasePaths`: Adds support for single-table inheritance _via_ "enum" tables by
+  * `CasePaths`: Adds support for single-table inheritance _via_ "enum" tables by
     leveraging the [CasePaths](https://github.com/pointfreeco/swift-case-paths) library.
 
-  * `StructuredQueriesTagged`: Adds support for type-safe identifiers _via_
+  * `Tagged`: Adds support for type-safe identifiers _via_
     the [Tagged](https://github.com/pointfreeco/swift-tagged) library.
 
 ```diff
@@ -245,8 +245,8 @@ support for other libraries:
      url: "https://github.com/pointfreeco/swift-structured-queries",
      from: "0.28.0",
 +    traits: [
-+      "StructuredQueriesCasePaths",
-+      "StructuredQueriesTagged",
++      "CasePaths",
++      "Tagged",
 +    ],
    ),
 +  .package(

--- a/Sources/StructuredQueriesCore/Documentation.docc/Articles/DefiningYourSchema.md
+++ b/Sources/StructuredQueriesCore/Documentation.docc/Articles/DefiningYourSchema.md
@@ -269,15 +269,15 @@ With that you can insert reminders with notes like so:
 
 The [Tagged](https://github.com/pointfreeco/swift-tagged) library provides lightweight syntax for
 introducing type-safe identifiers (and more) to your models. StructuredQueries ships support for
-Tagged with a `StructuredQueriesTagged` package trait, which is available starting from Swift 6.1.
+Tagged with a `Tagged` package trait, which is available starting from Swift 6.1.
 
 To enable the trait, specify it in the Package.swift file that depends on StructuredQueries:
 
 ```diff
  .package(
    url: "https://github.com/pointfreeco/swift-structured-queries",
-   from: "0.22.0",
-+  traits: ["StructuredQueriesTagged"]
+   from: "0.32.0",
++  traits: ["Tagged"]
  ),
 +.package(
 +  url: "https://github.com/pointfreeco/swift-tagged",
@@ -515,7 +515,7 @@ attachments supported, annotated with the `@Selection` macro:
 
 > Important: It is required to apply the `@CasePathable` macro in order to define columns from an
 > enum. This macro comes from our [Case Paths] library and is automatically included with the
-> library when the `StructuredQueriesCasePaths` trait is enabled.
+> library when the `CasePaths` trait is enabled.
 
 [Case Paths]: http://github.com/pointfreeco/swift-case-paths
 

--- a/Sources/StructuredQueriesCore/Traits/CasePaths.swift
+++ b/Sources/StructuredQueriesCore/Traits/CasePaths.swift
@@ -1,3 +1,3 @@
-#if !EXCLUDE_EXPORTS && StructuredQueriesCasePaths
+#if !EXCLUDE_EXPORTS && CasePaths
   @_exported import CasePaths
 #endif

--- a/Sources/StructuredQueriesCore/Traits/Tagged.swift
+++ b/Sources/StructuredQueriesCore/Traits/Tagged.swift
@@ -1,4 +1,4 @@
-#if StructuredQueriesTagged
+#if Tagged
   public import Tagged
 
   extension Tagged: _OptionalPromotable where RawValue: _OptionalPromotable {}

--- a/Sources/StructuredQueriesMacros/Internal/DeclGroupSyntax.swift
+++ b/Sources/StructuredQueriesMacros/Internal/DeclGroupSyntax.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 extension DeclGroupSyntax {
   var isTableMacroSupported: Bool {
-    #if StructuredQueriesCasePaths
+    #if CasePaths
       self.is(StructDeclSyntax.self) || self.is(EnumDeclSyntax.self)
     #else
       self.is(StructDeclSyntax.self)

--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -56,12 +56,12 @@ extension TableMacro: ExtensionMacro {
           message: MacroExpansionErrorMessage(
             declaration.is(EnumDeclSyntax.self)
               ? """
-              '@Table' can only be applied to enum types when the 'StructuredQueriesCasePaths' \
+              '@Table' can only be applied to enum types when the 'CasePaths' \
               package trait is enabled
               """
               : """
               '@Table' can only be applied to struct types (and enum types with the \
-              'StructuredQueriesCasePaths' package trait enabled)
+              'CasePaths' package trait enabled)
               """
           )
         )

--- a/Sources/StructuredQueriesSQLiteCore/Cast.swift
+++ b/Sources/StructuredQueriesSQLiteCore/Cast.swift
@@ -107,7 +107,7 @@ extension _CodableJSONRepresentation: SQLiteType {
   }
 }
 
-#if StructuredQueriesTagged
+#if Tagged
   public import Tagged
 
   extension Tagged: SQLiteType where RawValue: SQLiteType {

--- a/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
@@ -2498,7 +2498,7 @@ extension SnapshotTests {
     }
   }
 
-  #if StructuredQueriesCasePaths
+  #if CasePaths
     @Test func enumBasics() {
       assertMacro {
         """

--- a/Tests/StructuredQueriesTests/EnumTableTests.swift
+++ b/Tests/StructuredQueriesTests/EnumTableTests.swift
@@ -1,4 +1,4 @@
-#if StructuredQueriesCasePaths
+#if CasePaths
   import CasePaths
   import Dependencies
   import Foundation

--- a/Tests/StructuredQueriesTests/NestedTests.swift
+++ b/Tests/StructuredQueriesTests/NestedTests.swift
@@ -6,7 +6,7 @@ import StructuredQueriesTestSupport
 import Testing
 import _StructuredQueriesSQLite
 
-#if StructuredQueriesCasePaths
+#if CasePaths
   import CasePaths
 #endif
 
@@ -527,7 +527,7 @@ extension SnapshotTests {
       }
     }
 
-    #if StructuredQueriesCasePaths
+    #if CasePaths
       @Test func `enum`() throws {
         try db.execute(
           #sql(
@@ -713,7 +713,7 @@ private struct Note {
   let body: String
 }
 
-#if StructuredQueriesCasePaths
+#if CasePaths
   @CasePathable @Table
   private enum Post {
     case photo(Photo)

--- a/Tests/StructuredQueriesTests/TaggedTests.swift
+++ b/Tests/StructuredQueriesTests/TaggedTests.swift
@@ -1,4 +1,4 @@
-#if StructuredQueriesTagged
+#if Tagged
   import Dependencies
   import Foundation
   import InlineSnapshotTesting


### PR DESCRIPTION
We added the longer `StructuredQueries*` form early on when traits were first introduced to SPM, but community convention has converged on this shorter form.

Leaving the longer form around for now for backwards compatibility, but we can hard-hard-deprecate in a future 0.x using `#error`, and totally remove for 1.x.

We could also emit warnings from `@Table`...but that might be weird?