### PR TITLE
Add `is` operator to `@Selection enum`s

### DIFF
--- a/Sources/StructuredQueriesCore/Traits/CasePaths.swift
+++ b/Sources/StructuredQueriesCore/Traits/CasePaths.swift
@@ -1,3 +1,41 @@
-#if !EXCLUDE_EXPORTS && CasePaths
-  @_exported import CasePaths
+#if CasePaths
+  #if EXCLUDE_EXPORTS
+    import CasePaths
+  #else
+    @_exported import CasePaths
+  #endif
+
+  extension ColumnGroup where QueryValue: CasePathable & Table {
+    /// A Boolean query expression that checks if the given enum columns will be decoded for the
+    /// given case.
+    ///
+    /// - Parameter keyPath: A key path from enum columns to a case.
+    /// - Returns: A Boolean query expression
+    public func `is`<V>(
+      _ keyPath: KeyPath<QueryValue.TableColumns, TableColumn<Values.QueryOutput, V>>
+    ) -> some QueryExpression<Bool> {
+      SQLQueryExpression(
+        self[dynamicMember: keyPath]._allColumns.map {
+          "(\($0.queryFragment) IS NOT NULL)"
+        }
+        .joined(separator: " OR ")
+      )
+    }
+
+    /// A Boolean query expression that checks if the given enum columns will be decoded for the
+    /// given case.
+    ///
+    /// - Parameter keyPath: A key path from enum columns to a case.
+    /// - Returns: A Boolean query expression
+    public func `is`<V>(
+      _ keyPath: KeyPath<QueryValue.TableColumns, ColumnGroup<Values.QueryOutput, V>>
+    ) -> some QueryExpression<Bool> {
+      return SQLQueryExpression(
+        self[dynamicMember: keyPath]._allColumns.map {
+          "(\($0.queryFragment) IS NOT NULL)"
+        }
+        .joined(separator: " OR ")
+      )
+    }
+  }
 #endif

--- a/Sources/StructuredQueriesCore/Traits/CasePaths.swift
+++ b/Sources/StructuredQueriesCore/Traits/CasePaths.swift
@@ -1,6 +1,6 @@
 #if CasePaths
   #if EXCLUDE_EXPORTS
-    import CasePaths
+    public import CasePaths
   #else
     @_exported import CasePaths
   #endif

--- a/Sources/StructuredQueriesCore/Traits/CasePaths.swift
+++ b/Sources/StructuredQueriesCore/Traits/CasePaths.swift
@@ -12,14 +12,9 @@
     /// - Parameter keyPath: A key path from enum columns to a case.
     /// - Returns: A Boolean query expression
     public func `is`<V>(
-      _ keyPath: KeyPath<QueryValue.TableColumns, TableColumn<Values.QueryOutput, V>>
+      _ keyPath: KeyPath<Values.TableColumns, TableColumn<Values.QueryOutput, V>>
     ) -> some QueryExpression<Bool> {
-      SQLQueryExpression(
-        self[dynamicMember: keyPath]._allColumns.map {
-          "(\($0.queryFragment) IS NOT NULL)"
-        }
-        .joined(separator: " OR ")
-      )
+      self[dynamicMember: keyPath].isNot(nil)
     }
 
     /// A Boolean query expression that checks if the given enum columns will be decoded for the
@@ -28,14 +23,9 @@
     /// - Parameter keyPath: A key path from enum columns to a case.
     /// - Returns: A Boolean query expression
     public func `is`<V>(
-      _ keyPath: KeyPath<QueryValue.TableColumns, ColumnGroup<Values.QueryOutput, V>>
+      _ keyPath: KeyPath<Values.TableColumns, ColumnGroup<Values.QueryOutput, V>>
     ) -> some QueryExpression<Bool> {
-      return SQLQueryExpression(
-        self[dynamicMember: keyPath]._allColumns.map {
-          "(\($0.queryFragment) IS NOT NULL)"
-        }
-        .joined(separator: " OR ")
-      )
+      self[dynamicMember: keyPath].isNot(nil)
     }
   }
 #endif

--- a/Tests/StructuredQueriesTests/EnumTableTests.swift
+++ b/Tests/StructuredQueriesTests/EnumTableTests.swift
@@ -130,6 +130,50 @@
         }
       }
 
+      @Test func isOperator() {
+        assertQuery(
+          Attachment.where { $0.kind.is(\.note) }
+        ) {
+          """
+          SELECT "attachments"."id", "attachments"."link", "attachments"."note", "attachments"."videoURL", "attachments"."videoKind", "attachments"."imageCaption", "attachments"."imageURL"
+          FROM "attachments"
+          WHERE (("attachments"."note" IS NOT NULL))
+          """
+        } results: {
+          """
+          ┌───────────────────────────────────────┐
+          │ Attachment(                           │
+          │   id: 2,                              │
+          │   kind: .note("Today was a good day") │
+          │ )                                     │
+          └───────────────────────────────────────┘
+          """
+        }
+        assertQuery(
+          Attachment.where { $0.kind.is(\.video) }
+        ) {
+          """
+          SELECT "attachments"."id", "attachments"."link", "attachments"."note", "attachments"."videoURL", "attachments"."videoKind", "attachments"."imageCaption", "attachments"."imageURL"
+          FROM "attachments"
+          WHERE (("attachments"."videoURL" IS NOT NULL) OR ("attachments"."videoKind" IS NOT NULL))
+          """
+        } results: {
+          """
+          ┌─────────────────────────────────────────────────────┐
+          │ Attachment(                                         │
+          │   id: 3,                                            │
+          │   kind: .video(                                     │
+          │     Attachment.Video(                               │
+          │       url: URL(https://www.youtube.com/video/1234), │
+          │       kind: .youtube                                │
+          │     )                                               │
+          │   )                                                 │
+          │ )                                                   │
+          └─────────────────────────────────────────────────────┘
+          """
+        }
+      }
+
       @Test func dynamicMemberLookup_CasePath() {
         assertQuery(
           Attachment.select(\.kind.image)

--- a/Tests/StructuredQueriesTests/EnumTableTests.swift
+++ b/Tests/StructuredQueriesTests/EnumTableTests.swift
@@ -137,7 +137,7 @@
           """
           SELECT "attachments"."id", "attachments"."link", "attachments"."note", "attachments"."videoURL", "attachments"."videoKind", "attachments"."imageCaption", "attachments"."imageURL"
           FROM "attachments"
-          WHERE (("attachments"."note" IS NOT NULL))
+          WHERE (("attachments"."note") IS NOT (NULL))
           """
         } results: {
           """
@@ -155,7 +155,7 @@
           """
           SELECT "attachments"."id", "attachments"."link", "attachments"."note", "attachments"."videoURL", "attachments"."videoKind", "attachments"."imageCaption", "attachments"."imageURL"
           FROM "attachments"
-          WHERE (("attachments"."videoURL" IS NOT NULL) OR ("attachments"."videoKind" IS NOT NULL))
+          WHERE (("attachments"."videoURL", "attachments"."videoKind") IS NOT (NULL, NULL))
           """
         } results: {
           """
@@ -170,6 +170,26 @@
           │   )                                                 │
           │ )                                                   │
           └─────────────────────────────────────────────────────┘
+          """
+        }
+        assertQuery(
+          Attachment
+            .select { $0.kind.video }
+            .where { $0.kind.video.isNot(nil) }
+        ) {
+          """
+          SELECT "attachments"."videoURL", "attachments"."videoKind"
+          FROM "attachments"
+          WHERE (("attachments"."videoURL", "attachments"."videoKind") IS NOT (NULL, NULL))
+          """
+        } results: {
+          """
+          ┌─────────────────────────────────────────────────┐
+          │ Attachment.Video(                               │
+          │   url: URL(https://www.youtube.com/video/1234), │
+          │   kind: .youtube                                │
+          │ )                                               │
+          └─────────────────────────────────────────────────┘
           """
         }
       }


### PR DESCRIPTION
Allows you to query to filter by a particular case:

```swift
Attachment.where { $0.kind.is(\.note) }
```