### PR TITLE
Generalize drafts to any table with lazy-initializable columns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run tests
-        run: swift test --enable-all-traits
+        run: swift test --traits CasePaths,Tagged
       - name: Build without exports
         run: swift build -c release -Xswiftc -D -Xswiftc EXCLUDE_EXPORTS --enable-all-traits
       - name: Build release

--- a/Sources/StructuredQueriesCore/Internal/Deprecations.swift
+++ b/Sources/StructuredQueriesCore/Internal/Deprecations.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+// NB: Deprecated after 0.32.0:
+
+extension TableDraft {
+  @available(*, deprecated, renamed: "SourceTable")
+  public typealias PrimaryTable = SourceTable
+}
+
 // NB: Deprecated after 0.6.0:
 
 extension QueryFragment {

--- a/Sources/StructuredQueriesCore/Optional.swift
+++ b/Sources/StructuredQueriesCore/Optional.swift
@@ -79,6 +79,8 @@ extension Optional: QueryRepresentable where Wrapped: QueryRepresentable {
 }
 
 extension Optional: Table, PartialSelectStatement, Statement where Wrapped: Table {
+  public typealias Draft = Wrapped.Draft?
+
   public static var tableName: String {
     Wrapped.tableName
   }
@@ -185,13 +187,11 @@ extension Optional: Table, PartialSelectStatement, Statement where Wrapped: Tabl
 
 extension Optional: _Selection where Wrapped: _Selection {}
 
-extension Optional: PrimaryKeyedTable where Wrapped: PrimaryKeyedTable {
-  public typealias Draft = Wrapped.Draft?
-}
+extension Optional: PrimaryKeyedTable where Wrapped: PrimaryKeyedTable {}
 
 extension Optional: TableDraft where Wrapped: TableDraft {
-  public typealias PrimaryTable = Wrapped.PrimaryTable?
-  public init(_ primaryTable: Wrapped.PrimaryTable?) {
+  public typealias SourceTable = Wrapped.SourceTable?
+  public init(_ primaryTable: Wrapped.SourceTable?) {
     self = primaryTable.map(Wrapped.init)
   }
 }

--- a/Sources/StructuredQueriesCore/PrimaryKeyed.swift
+++ b/Sources/StructuredQueriesCore/PrimaryKeyed.swift
@@ -1,49 +1,50 @@
 /// A type representing a database table with a primary key.
 public protocol PrimaryKeyedTable<PrimaryKey>: Table
-where TableColumns: PrimaryKeyedTableDefinition<PrimaryKey> {
+where
+  TableColumns: PrimaryKeyedTableDefinition<PrimaryKey>,
+  Draft: TableDraft,
+  Draft.SourceTable == Self
+{
   /// A type representing this table's primary key.
   ///
   /// For auto-incrementing tables, this is typically `Int`.
   associatedtype PrimaryKey: QueryRepresentable & QueryExpression
   where PrimaryKey.QueryValue == PrimaryKey
-
-  /// A type that represents this type, but with an optional primary key.
-  ///
-  /// This type can be used to stage an inserted row.
-  associatedtype Draft: TableDraft where Draft.PrimaryTable == Self
 }
 
-// A type representing a draft to be saved to a table with a primary key.
+// A type representing a draft to be saved to a table.
 public protocol TableDraft: Table {
-  /// A type that represents the table with a primary key.
-  associatedtype PrimaryTable: PrimaryKeyedTable where PrimaryTable.Draft == Self
+  /// A type that represents the table this draft stages a row for.
+  associatedtype SourceTable: Table where SourceTable.Draft == Self
 
-  typealias PrimaryKey = PrimaryTable.PrimaryKey
+  /// Creates a draft from a persisted table row.
+  init(_ source: SourceTable)
+}
 
-  /// Creates a draft from a primary-keyed table.
-  init(_ primaryTable: PrimaryTable)
+extension TableDraft where SourceTable: PrimaryKeyedTable {
+  public typealias PrimaryKey = SourceTable.PrimaryKey
 }
 
 extension TableDraft {
   public static subscript(
-    dynamicMember keyPath: KeyPath<PrimaryTable.Type, some Statement<PrimaryTable>>
+    dynamicMember keyPath: KeyPath<SourceTable.Type, some Statement<SourceTable>>
   ) -> some Statement<Self> {
-    SQLQueryExpression("\(PrimaryTable.self[keyPath: keyPath])")
+    SQLQueryExpression("\(SourceTable.self[keyPath: keyPath])")
   }
 
   public static subscript(
-    dynamicMember keyPath: KeyPath<PrimaryTable.Type, some SelectStatementOf<PrimaryTable>>
+    dynamicMember keyPath: KeyPath<SourceTable.Type, some SelectStatementOf<SourceTable>>
   ) -> SelectOf<Self> {
-    unsafeBitCast(PrimaryTable.self[keyPath: keyPath].asSelect(), to: SelectOf<Self>.self)
+    unsafeBitCast(SourceTable.self[keyPath: keyPath].asSelect(), to: SelectOf<Self>.self)
   }
 
   public static var all: SelectOf<Self> {
-    unsafeBitCast(PrimaryTable.all.asSelect(), to: SelectOf<Self>.self)
+    unsafeBitCast(SourceTable.all.asSelect(), to: SelectOf<Self>.self)
   }
 
-  public static var schemaName: String? { PrimaryTable.schemaName }
+  public static var schemaName: String? { SourceTable.schemaName }
 
-  public static var tableName: String { PrimaryTable.tableName }
+  public static var tableName: String { SourceTable.tableName }
 }
 
 /// A type representing a database table's columns.
@@ -66,9 +67,9 @@ where QueryValue: PrimaryKeyedTable {
 
 extension TableDefinition where QueryValue: TableDraft {
   public subscript<Member>(
-    dynamicMember keyPath: KeyPath<QueryValue.PrimaryTable.TableColumns, Member>
+    dynamicMember keyPath: KeyPath<QueryValue.SourceTable.TableColumns, Member>
   ) -> Member {
-    QueryValue.PrimaryTable.columns[keyPath: keyPath]
+    QueryValue.SourceTable.columns[keyPath: keyPath]
   }
 }
 
@@ -114,13 +115,13 @@ extension PrimaryKeyedTable {
   }
 }
 
-extension TableDraft {
+extension TableDraft where SourceTable: PrimaryKeyedTable {
   /// A where clause filtered by a primary key.
   ///
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: A `WHERE` clause.
   public static func find(
-    _ primaryKey: some QueryExpression<PrimaryKey>
+    _ primaryKey: some QueryExpression<SourceTable.PrimaryKey>
   ) -> Where<Self> {
     find([primaryKey])
   }
@@ -130,7 +131,7 @@ extension TableDraft {
   /// - Parameter primaryKeys: Primary keys identifying table rows.
   /// - Returns: A `WHERE` clause.
   public static func find(
-    _ primaryKeys: some Sequence<some QueryExpression<PrimaryKey>>
+    _ primaryKeys: some Sequence<some QueryExpression<SourceTable.PrimaryKey>>
   ) -> Where<Self> {
     Self.where { $0.primaryKey.in(primaryKeys) }
   }
@@ -156,12 +157,12 @@ extension Where where From: PrimaryKeyedTable {
   }
 }
 
-extension Where where From: TableDraft {
+extension Where where From: TableDraft, From.SourceTable: PrimaryKeyedTable {
   /// Adds a primary key condition to a where clause.
   ///
   /// - Parameter primaryKey: A primary key.
   /// - Returns: A where clause with the added primary key.
-  public func find(_ primaryKey: some QueryExpression<From.PrimaryKey>)
+  public func find(_ primaryKey: some QueryExpression<From.SourceTable.PrimaryKey>)
     -> Self
   {
     find([primaryKey])
@@ -172,7 +173,7 @@ extension Where where From: TableDraft {
   /// - Parameter primaryKeys: A sequence of primary keys.
   /// - Returns: A where clause with the added primary keys condition.
   public func find(
-    _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryKey>>
+    _ primaryKeys: some Sequence<some QueryExpression<From.SourceTable.PrimaryKey>>
   ) -> Self {
     self.where { $0.primaryKey.in(primaryKeys) }
   }
@@ -198,13 +199,13 @@ extension Select where From: PrimaryKeyedTable {
   }
 }
 
-extension Select where From: TableDraft {
+extension Select where From: TableDraft, From.SourceTable: PrimaryKeyedTable {
   /// A select statement filtered by a primary key.
   ///
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: A select statement filtered by the given key.
   public func find(
-    _ primaryKey: some QueryExpression<From.PrimaryKey>
+    _ primaryKey: some QueryExpression<From.SourceTable.PrimaryKey>
   ) -> Self {
     and(From.find(primaryKey))
   }
@@ -214,7 +215,7 @@ extension Select where From: TableDraft {
   /// - Parameter primaryKeys: A sequence of primary keys.
   /// - Returns: A select statement filtered by the given keys.
   public func find(
-    _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryKey>>
+    _ primaryKeys: some Sequence<some QueryExpression<From.SourceTable.PrimaryKey>>
   ) -> Self {
     and(From.find(primaryKeys))
   }
@@ -240,12 +241,12 @@ extension Update where From: PrimaryKeyedTable {
   }
 }
 
-extension Update where From: TableDraft {
+extension Update where From: TableDraft, From.SourceTable: PrimaryKeyedTable {
   /// An update statement filtered by a primary key.
   ///
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: An update statement filtered by the given key.
-  public func find(_ primaryKey: some QueryExpression<From.PrimaryKey>)
+  public func find(_ primaryKey: some QueryExpression<From.SourceTable.PrimaryKey>)
     -> Self
   {
     find([primaryKey])
@@ -256,7 +257,7 @@ extension Update where From: TableDraft {
   /// - Parameter primaryKeys: A sequence of primary keys.
   /// - Returns: An update statement filtered by the given keys.
   public func find(
-    _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryKey>>
+    _ primaryKeys: some Sequence<some QueryExpression<From.SourceTable.PrimaryKey>>
   ) -> Self {
     self.where { $0.primaryKey.in(primaryKeys) }
   }
@@ -282,12 +283,12 @@ extension Delete where From: PrimaryKeyedTable {
   }
 }
 
-extension Delete where From: TableDraft {
+extension Delete where From: TableDraft, From.SourceTable: PrimaryKeyedTable {
   /// A delete statement filtered by a primary key.
   ///
   /// - Parameter primaryKey: A primary key identifying a table row.
   /// - Returns: A delete statement filtered by the given key.
-  public func find(_ primaryKey: some QueryExpression<From.PrimaryKey>)
+  public func find(_ primaryKey: some QueryExpression<From.SourceTable.PrimaryKey>)
     -> Self
   {
     find([primaryKey])
@@ -298,7 +299,7 @@ extension Delete where From: TableDraft {
   /// - Parameter primaryKeys: A sequence of primary keys.
   /// - Returns: A delete statement filtered by the given keys.
   public func find(
-    _ primaryKeys: some Sequence<some QueryExpression<From.PrimaryKey>>
+    _ primaryKeys: some Sequence<some QueryExpression<From.SourceTable.PrimaryKey>>
   ) -> Self {
     self.where { $0.primaryKey.in(primaryKeys) }
   }

--- a/Sources/StructuredQueriesCore/Seeds.swift
+++ b/Sources/StructuredQueriesCore/Seeds.swift
@@ -87,7 +87,7 @@ public struct Seeds: Sequence {
         func insertBatch<T: TableDraft>(_: T.Type) -> SQLQueryExpression<Void> {
           let batch = Array(seeds.lazy.prefix { $0 is T }.compactMap { $0 as? T })
           defer { seeds.removeFirst(batch.count) }
-          return SQLQueryExpression(T.PrimaryTable.insert { batch })
+          return SQLQueryExpression(T.SourceTable.insert { batch })
         }
 
         return insertBatch(firstType)

--- a/Sources/StructuredQueriesCore/Statements/Insert.swift
+++ b/Sources/StructuredQueriesCore/Statements/Insert.swift
@@ -923,7 +923,7 @@ public enum InsertValuesBuilder<Value> {
 
   @_disfavoredOverload
   public static func buildExpression(_ expression: [Value.Draft]) -> [[QueryFragment]]
-  where Value: PrimaryKeyedTable {
+  where Value: Table, Value.Draft: TableDraft {
     var valueFragments: [[QueryFragment]] = []
     for value in expression {
       var valueFragment: [QueryFragment] = []
@@ -965,7 +965,7 @@ public enum InsertValuesBuilder<Value> {
   }
 
   public static func buildExpression(_ expression: Value.Draft) -> [[QueryFragment]]
-  where Value: PrimaryKeyedTable {
+  where Value: Table, Value.Draft: TableDraft {
     buildExpression([expression])
   }
 

--- a/Sources/StructuredQueriesCore/Statements/Select+DynamicMemberLookup.swift
+++ b/Sources/StructuredQueriesCore/Statements/Select+DynamicMemberLookup.swift
@@ -192,14 +192,14 @@
     public subscript<
       each C: QueryRepresentable,
       each J: Table,
-      S: SelectStatement<(), From.PrimaryTable, ()>
+      S: SelectStatement<(), From.SourceTable, ()>
     >(
-      dynamicMember keyPath: KeyPath<From.PrimaryTable.Type, S>
+      dynamicMember keyPath: KeyPath<From.SourceTable.Type, S>
     ) -> Select<(repeat each C), From, (repeat each J)>
     where Columns == (repeat each C), Joins == (repeat each J) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath].asSelect(),
+          From.SourceTable.self[keyPath: keyPath].asSelect(),
           to: Select<(), From, ()>.self
         )
     }
@@ -209,12 +209,12 @@
       C2: QueryRepresentable,
       each J: Table
     >(
-      dynamicMember keyPath: KeyPath<From.PrimaryTable.Type, Select<C2, From.PrimaryTable, ()>>
+      dynamicMember keyPath: KeyPath<From.SourceTable.Type, Select<C2, From.SourceTable, ()>>
     ) -> Select<(repeat each C1, C2), From, (repeat each J)>
     where Columns == (repeat each C1), Joins == (repeat each J) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<C2, From, ()>.self
         )
     }
@@ -226,13 +226,13 @@
       each J: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(C2, C3), From.PrimaryTable, ()>
+        From.SourceTable.Type, Select<(C2, C3), From.SourceTable, ()>
       >
     ) -> Select<(repeat each C1, C2, C3), From, (repeat each J)>
     where Columns == (repeat each C1), Joins == (repeat each J) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(C2, C3), From, ()>.self
         )
     }
@@ -245,13 +245,13 @@
       each J: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(C2, C3, C4), From.PrimaryTable, ()>
+        From.SourceTable.Type, Select<(C2, C3, C4), From.SourceTable, ()>
       >
     ) -> Select<(repeat each C1, C2, C3, C4), From, (repeat each J)>
     where Columns == (repeat each C1), Joins == (repeat each J) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(C2, C3, C4), From, ()>.self
         )
     }
@@ -265,13 +265,13 @@
       each J: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(C2, C3, C4, C5), From.PrimaryTable, ()>
+        From.SourceTable.Type, Select<(C2, C3, C4, C5), From.SourceTable, ()>
       >
     ) -> Select<(repeat each C1, C2, C3, C4, C5), From, (repeat each J)>
     where Columns == (repeat each C1), Joins == (repeat each J) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(C2, C3, C4, C5), From, ()>.self
         )
     }
@@ -282,12 +282,12 @@
       each J1: Table,
       J2: Table
     >(
-      dynamicMember keyPath: KeyPath<From.PrimaryTable.Type, Select<C2, From.PrimaryTable, J2>>
+      dynamicMember keyPath: KeyPath<From.SourceTable.Type, Select<C2, From.SourceTable, J2>>
     ) -> Select<(repeat each C1, C2), From, (repeat each J1, J2)>
     where Columns == (repeat each C1), Joins == (repeat each J1) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<C2, From, J2>.self
         )
     }
@@ -300,13 +300,13 @@
       J2: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(C2, C3), From.PrimaryTable, J2>
+        From.SourceTable.Type, Select<(C2, C3), From.SourceTable, J2>
       >
     ) -> Select<(repeat each C1, C2, C3), From, (repeat each J1, J2)>
     where Columns == (repeat each C1), Joins == (repeat each J1) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(C2, C3), From, J2>.self
         )
     }
@@ -320,13 +320,13 @@
       J2: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(C2, C3, C4), From.PrimaryTable, J2>
+        From.SourceTable.Type, Select<(C2, C3, C4), From.SourceTable, J2>
       >
     ) -> Select<(repeat each C1, C2, C3, C4), From, (repeat each J1, J2)>
     where Columns == (repeat each C1), Joins == (repeat each J1) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(C2, C3, C4), From, J2>.self
         )
     }
@@ -341,13 +341,13 @@
       J2: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(C2, C3, C4, C5), From.PrimaryTable, J2>
+        From.SourceTable.Type, Select<(C2, C3, C4, C5), From.SourceTable, J2>
       >
     ) -> Select<(repeat each C1, C2, C3, C4, C5), From, (repeat each J1, J2)>
     where Columns == (repeat each C1), Joins == (repeat each J1) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(C2, C3, C4, C5), From, J2>.self
         )
     }
@@ -359,13 +359,13 @@
       J3: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(), From.PrimaryTable, (J2, J3)>
+        From.SourceTable.Type, Select<(), From.SourceTable, (J2, J3)>
       >
     ) -> Select<(repeat each C), From, (repeat each J1, J2, J3)>
     where Columns == (repeat each C), Joins == (repeat each J1) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(), From, (J2, J3)>.self
         )
     }
@@ -378,13 +378,13 @@
       J3: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<C2, From.PrimaryTable, (J2, J3)>
+        From.SourceTable.Type, Select<C2, From.SourceTable, (J2, J3)>
       >
     ) -> Select<(repeat each C1, C2), From, (repeat each J1, J2, J3)>
     where Columns == (repeat each C1), Joins == (repeat each J1) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<C2, From, (J2, J3)>.self
         )
     }
@@ -398,13 +398,13 @@
       J3: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(C2, C3), From.PrimaryTable, (J2, J3)>
+        From.SourceTable.Type, Select<(C2, C3), From.SourceTable, (J2, J3)>
       >
     ) -> Select<(repeat each C1, C2, C3), From, (repeat each J1, J2, J3)>
     where Columns == (repeat each C1), Joins == (repeat each J1) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(C2, C3), From, (J2, J3)>.self
         )
     }
@@ -419,13 +419,13 @@
       J3: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(C2, C3, C4), From.PrimaryTable, (J2, J3)>
+        From.SourceTable.Type, Select<(C2, C3, C4), From.SourceTable, (J2, J3)>
       >
     ) -> Select<(repeat each C1, C2, C3, C4), From, (repeat each J1, J2, J3)>
     where Columns == (repeat each C1), Joins == (repeat each J1) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(C2, C3, C4), From, (J2, J3)>.self
         )
     }
@@ -441,13 +441,13 @@
       J3: Table
     >(
       dynamicMember keyPath: KeyPath<
-        From.PrimaryTable.Type, Select<(C2, C3, C4, C5), From.PrimaryTable, (J2, J3)>
+        From.SourceTable.Type, Select<(C2, C3, C4, C5), From.SourceTable, (J2, J3)>
       >
     ) -> Select<(repeat each C1, C2, C3, C4, C5), From, (repeat each J1, J2, J3)>
     where Columns == (repeat each C1), Joins == (repeat each J1) {
       self
         + unsafeBitCast(
-          From.PrimaryTable.self[keyPath: keyPath],
+          From.SourceTable.self[keyPath: keyPath],
           to: Select<(C2, C3, C4, C5), From, (J2, J3)>.self
         )
     }

--- a/Sources/StructuredQueriesCore/Statements/Where.swift
+++ b/Sources/StructuredQueriesCore/Statements/Where.swift
@@ -85,10 +85,10 @@ public struct Where<From: Table>: Sendable {
     }
 
     public subscript(
-      dynamicMember keyPath: KeyPath<From.PrimaryTable.Type, Where<From.PrimaryTable>>
+      dynamicMember keyPath: KeyPath<From.SourceTable.Type, Where<From.SourceTable>>
     ) -> Self
     where From: TableDraft {
-      self + unsafeBitCast(From.PrimaryTable.self[keyPath: keyPath], to: Self.self)
+      self + unsafeBitCast(From.SourceTable.self[keyPath: keyPath], to: Self.self)
     }
   #endif
 }

--- a/Sources/StructuredQueriesCore/Table.swift
+++ b/Sources/StructuredQueriesCore/Table.swift
@@ -8,6 +8,11 @@ public protocol Table: QueryRepresentable, PartialSelectStatement {
 
   associatedtype From = Never
 
+  /// A type that represents this type, but with lazily initializable data.
+  ///
+  /// This type can be used to stage an inserted row.
+  associatedtype Draft = Never
+
   /// A type that describes this table's columns.
   associatedtype TableColumns: TableDefinition<Self>
 

--- a/Sources/StructuredQueriesCore/TableAlias.swift
+++ b/Sources/StructuredQueriesCore/TableAlias.swift
@@ -86,9 +86,22 @@ extension Table {
 ///
 /// This type is returned from ``Table/as(_:)``.
 public struct TableAlias<
-  Base: Table,
+  Base,
   Name: AliasName  // We should use a value generic here when it's possible.
->: _OptionalPromotable, Table {
+>: _OptionalPromotable {
+  let base: Base
+
+  subscript<Member: QueryRepresentable>(
+    member _: KeyPath<Member, Member>,
+    column keyPath: KeyPath<Base, Member.QueryOutput>
+  ) -> Member.QueryOutput {
+    base[keyPath: keyPath]
+  }
+}
+
+extension TableAlias: Table, PartialSelectStatement, Statement where Base: Table {
+  public typealias Draft = TableAlias<Base.Draft, Name>
+
   public static var columns: TableColumns {
     TableColumns()
   }
@@ -115,15 +128,6 @@ public struct TableAlias<
     select.clauses.order = select.clauses.order
       .map { $0.replacingOccurrences(of: Base.self, with: Name.self) }
     return select
-  }
-
-  let base: Base
-
-  subscript<Member: QueryRepresentable>(
-    member _: KeyPath<Member, Member>,
-    column keyPath: KeyPath<Base, Member.QueryOutput>
-  ) -> Member.QueryOutput {
-    base[keyPath: keyPath]
   }
 
   @dynamicMemberLookup
@@ -200,13 +204,11 @@ public struct TableAlias<
 
 extension TableAlias: _Selection where Base: _Selection {}
 
-extension TableAlias: PrimaryKeyedTable where Base: PrimaryKeyedTable {
-  public typealias Draft = TableAlias<Base.Draft, Name>
-}
+extension TableAlias: PrimaryKeyedTable where Base: PrimaryKeyedTable {}
 
 extension TableAlias: TableDraft where Base: TableDraft {
-  public typealias PrimaryTable = TableAlias<Base.PrimaryTable, Name>
-  public init(_ primaryTable: TableAlias<Base.PrimaryTable, Name>) {
+  public typealias SourceTable = TableAlias<Base.SourceTable, Name>
+  public init(_ primaryTable: TableAlias<Base.SourceTable, Name>) {
     self.init(base: Base(primaryTable.base))
   }
 }

--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -647,7 +647,7 @@ extension TableMacro: ExtensionMacro {
     if draftTableType != nil {
       initFromOther = """
 
-        \(raw: initAccess)\(nonisolated)init(_ other: PrimaryTable) {
+        \(raw: initAccess)\(nonisolated)init(_ other: SourceTable) {
         \(allColumns.map { "self.\($0) = other.\($0)" as ExprSyntax }, separator: "\n")
         }
         """
@@ -797,6 +797,7 @@ extension TableMacro: MemberMacro {
     var expansionFailed = false
 
     var draftProperties: [DeclSyntax] = []
+    var draftHasLazyColumn = false
     var primaryKey:
       (
         identifier: TokenSyntax,
@@ -1051,6 +1052,7 @@ extension TableMacro: MemberMacro {
             let type = binding.typeAnnotation?.type,
             !type.isOptionalType
           {
+            draftHasLazyColumn = true
             var property = property
             for attributeIndex in property.attributes.indices {
               guard
@@ -1264,7 +1266,7 @@ extension TableMacro: MemberMacro {
     }
 
     var draft: DeclSyntax?
-    if primaryKey != nil {
+    if node.attributeName.identifier != "_Draft", primaryKey != nil || draftHasLazyColumn {
       let draftAccess: String
       switch declaration.accessLevelModifier?.name.tokenKind {
       case .keyword(.private), .keyword(.fileprivate):
@@ -1278,7 +1280,7 @@ extension TableMacro: MemberMacro {
 
         @_Draft(\(type).self)
         \(raw: draftAccess)struct Draft: \(moduleName).TableDraft, \(moduleName).PartialSelectStatement {
-        public typealias PrimaryTable = \(type)
+        public typealias SourceTable = \(type)
         \(draftProperties, separator: "\n")
         }
         """

--- a/Tests/StructuredQueriesMacrosTests/LazyInitializableTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/LazyInitializableTests.swift
@@ -73,7 +73,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Place
+            public typealias SourceTable = Place
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
             var latitude: Double?
@@ -149,7 +149,7 @@ extension SnapshotTests {
             self.latitude = try decoder.decode() ?? nil
             self.longitude = try decoder.decode() ?? nil
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.latitude = other.latitude
             self.longitude = other.longitude
@@ -254,7 +254,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Place
+            public typealias SourceTable = Place
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
             var latitude: Double
@@ -326,7 +326,7 @@ extension SnapshotTests {
             }
             self.latitude = latitude
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.latitude = other.latitude
           }
@@ -424,7 +424,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Event
+            public typealias SourceTable = Event
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
             var startsAt: Date?
@@ -492,7 +492,7 @@ extension SnapshotTests {
             self.id = try decoder.decode() ?? nil
             self.startsAt = try decoder.decode(Date.ISO8601Representation.self) ?? nil
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.startsAt = other.startsAt
           }
@@ -590,7 +590,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Place
+            public typealias SourceTable = Place
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
             var coordinate: Coordinate?
@@ -658,7 +658,7 @@ extension SnapshotTests {
             self.id = try decoder.decode() ?? nil
             self.coordinate = try decoder.decode() ?? nil
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.coordinate = other.coordinate
           }
@@ -756,7 +756,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Record
+            public typealias SourceTable = Record
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
             var systemFields: CKRecord?
@@ -828,7 +828,7 @@ extension SnapshotTests {
             }
             self.systemFields = systemFields
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.systemFields = other.systemFields
           }
@@ -974,7 +974,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Record
+            public typealias SourceTable = Record
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
             var a: String?
@@ -1058,7 +1058,7 @@ extension SnapshotTests {
             self.b = try decoder.decode() ?? nil
             self.c = try decoder.decode() ?? nil
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.a = other.a
             self.b = other.b
@@ -1096,6 +1096,197 @@ extension SnapshotTests {
             }
             self.id = id
             self.c = c
+          }
+        }
+        """#
+      }
+    }
+
+    @Test func nonPrimaryKeyedTableWithLazyColumnGeneratesDraft() {
+      assertMacro {
+        """
+        @Table
+        struct Location {
+          @Column(lazyInitializable: true)
+          var latitude: Double
+          @Column(lazyInitializable: true)
+          var longitude: Double
+          var name: String
+        }
+        """
+      } expansion: {
+        #"""
+        struct Location {
+          var latitude: Double
+          var longitude: Double
+          @StructuredQueries._ColumnCheck(String.self)
+          var name: String
+
+          public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
+            public typealias QueryValue = Location
+            public let latitude = StructuredQueriesCore.TableColumn<QueryValue, Double>("latitude", keyPath: \QueryValue.latitude)
+            public let longitude = StructuredQueriesCore.TableColumn<QueryValue, Double>("longitude", keyPath: \QueryValue.longitude)
+            public let name = StructuredQueriesCore._TableColumn<QueryValue, String>.for("name", keyPath: \QueryValue.name)
+            #if compiler(>=6.4)
+            @_optimize(none)
+            #endif
+            public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
+              var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
+              allColumns.append(contentsOf: QueryValue.columns.latitude._allColumns)
+              allColumns.append(contentsOf: QueryValue.columns.longitude._allColumns)
+              allColumns.append(contentsOf: QueryValue.columns.name._allColumns)
+              return allColumns
+            }
+            #if compiler(>=6.4)
+            @_optimize(none)
+            #endif
+            public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
+              var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] = []
+              writableColumns.append(contentsOf: QueryValue.columns.latitude._writableColumns)
+              writableColumns.append(contentsOf: QueryValue.columns.longitude._writableColumns)
+              writableColumns.append(contentsOf: QueryValue.columns.name._writableColumns)
+              return writableColumns
+            }
+            public var queryFragment: QueryFragment {
+              "\(self.latitude), \(self.longitude), \(self.name)"
+            }
+          }
+
+          public nonisolated struct Selection: StructuredQueriesCore.TableExpression {
+            public typealias QueryValue = Location
+            public let allColumns: [any StructuredQueriesCore.QueryExpression]
+            public init(
+              latitude: some StructuredQueriesCore.QueryExpression<Double>,
+              longitude: some StructuredQueriesCore.QueryExpression<Double>,
+              name: some StructuredQueriesCore.QueryExpression<String>
+            ) {
+              var allColumns: [any StructuredQueriesCore.QueryExpression] = []
+              allColumns.append(contentsOf: latitude._allColumns)
+              allColumns.append(contentsOf: longitude._allColumns)
+              allColumns.append(contentsOf: name._allColumns)
+              self.allColumns = allColumns
+            }
+          }
+          struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
+            public typealias SourceTable = Location
+            var latitude: Double?
+            var longitude: Double?
+            @StructuredQueries._ColumnCheck(String.self)
+            var name: String
+
+            public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
+              public typealias QueryValue = Draft
+              public let latitude = StructuredQueriesCore.TableColumn<QueryValue, Double?>("latitude", keyPath: \QueryValue.latitude, default: nil)
+              public let longitude = StructuredQueriesCore.TableColumn<QueryValue, Double?>("longitude", keyPath: \QueryValue.longitude, default: nil)
+              public let name = StructuredQueriesCore._TableColumn<QueryValue, String>.for("name", keyPath: \QueryValue.name)
+              #if compiler(>=6.4)
+              @_optimize(none)
+              #endif
+              public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
+                var allColumns: [any StructuredQueriesCore.TableColumnExpression] = []
+                allColumns.append(contentsOf: QueryValue.columns.latitude._allColumns)
+                allColumns.append(contentsOf: QueryValue.columns.longitude._allColumns)
+                allColumns.append(contentsOf: QueryValue.columns.name._allColumns)
+                return allColumns
+              }
+              #if compiler(>=6.4)
+              @_optimize(none)
+              #endif
+              public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
+                var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] = []
+                writableColumns.append(contentsOf: QueryValue.columns.latitude._writableColumns)
+                writableColumns.append(contentsOf: QueryValue.columns.longitude._writableColumns)
+                writableColumns.append(contentsOf: QueryValue.columns.name._writableColumns)
+                return writableColumns
+              }
+              public var queryFragment: QueryFragment {
+                "\(self.latitude), \(self.longitude), \(self.name)"
+              }
+            }
+
+            public nonisolated struct Selection: StructuredQueriesCore.TableExpression {
+              public typealias QueryValue = Draft
+              public let allColumns: [any StructuredQueriesCore.QueryExpression]
+              public init(
+                latitude: some StructuredQueriesCore.QueryExpression<Double?> = Double?(queryOutput: nil),
+                longitude: some StructuredQueriesCore.QueryExpression<Double?> = Double?(queryOutput: nil),
+                name: some StructuredQueriesCore.QueryExpression<String>
+              ) {
+                var allColumns: [any StructuredQueriesCore.QueryExpression] = []
+                allColumns.append(contentsOf: latitude._allColumns)
+                allColumns.append(contentsOf: longitude._allColumns)
+                allColumns.append(contentsOf: name._allColumns)
+                self.allColumns = allColumns
+              }
+            }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Double?._columnWidth
+              columnWidth += Double?._columnWidth
+              columnWidth += String._columnWidth
+              return columnWidth
+            }
+          }
+        }
+
+        nonisolated extension Draft {
+          nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+            self.latitude = try decoder.decode() ?? nil
+            self.longitude = try decoder.decode() ?? nil
+            let name = try decoder.decode(\QueryValue.name)
+            guard let name else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            self.name = name
+          }
+          nonisolated init(_ other: SourceTable) {
+            self.latitude = other.latitude
+            self.longitude = other.longitude
+            self.name = other.name
+          }
+        }
+
+        nonisolated extension Location: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
+          public typealias QueryValue = Self
+          public typealias From = Swift.Never
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+          public nonisolated static var _columnWidth: Int {
+            var columnWidth = 0
+            columnWidth += Double._columnWidth
+            columnWidth += Double._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
+          }
+          public nonisolated static var tableName: String {
+            "locations"
+          }
+          public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+            let latitude = try decoder.decode(\QueryValue.latitude)
+            let longitude = try decoder.decode(\QueryValue.longitude)
+            let name = try decoder.decode(\QueryValue.name)
+            guard let latitude else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            guard let longitude else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            guard let name else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            self.latitude = latitude
+            self.longitude = longitude
+            self.name = name
           }
         }
         """#
@@ -1182,7 +1373,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Place
+              public typealias SourceTable = Place
               @Column("id", primaryKey: true) @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @Column("latitude") @StructuredQueries._ColumnCheck(Double?.self)
@@ -1269,7 +1460,7 @@ extension SnapshotTests {
               self.name = try decoder.decode() ?? ""
               self.note = try decoder.decode() ?? nil
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.latitude = other.latitude
               self.name = other.name
@@ -1381,7 +1572,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Item
+              public typealias SourceTable = Item
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @StructuredQueries._ColumnCheck(Int?.self)
@@ -1459,7 +1650,7 @@ extension SnapshotTests {
               self.quantity = try decoder.decode() ?? nil
               self.note = try decoder.decode() ?? nil
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.quantity = other.quantity
               self.note = other.note
@@ -1574,7 +1765,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = User
+              public typealias SourceTable = User
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: /* TODO: UUID */ Int? // Primary key
               @StructuredQueries._ColumnCheck(String?.self)
@@ -1652,7 +1843,7 @@ extension SnapshotTests {
               self.email = try decoder.decode() ?? ""
               self.age = try decoder.decode() ?? nil
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.email = other.email
               self.age = other.age
@@ -1759,7 +1950,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = User
+              public typealias SourceTable = User
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @StructuredQueries._ColumnCheck(String?.self)
@@ -1828,7 +2019,7 @@ extension SnapshotTests {
               self.id = try decoder.decode() ?? nil
               self.name = try decoder.decode() ?? nil
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.name = other.name
             }
@@ -1934,7 +2125,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = SyncUp
+              public typealias SourceTable = SyncUp
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @StructuredQueries._ColumnCheck(String?.self)
@@ -2003,7 +2194,7 @@ extension SnapshotTests {
               self.id = try decoder.decode() ?? nil
               self.name = try decoder.decode() ?? nil
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.name = other.name
             }
@@ -2109,7 +2300,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Foo
+              public typealias SourceTable = Foo
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @StructuredQueries._ColumnCheck(String?.self)
@@ -2178,7 +2369,7 @@ extension SnapshotTests {
               self.id = try decoder.decode() ?? nil
               self.name = try decoder.decode() ?? nil
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.name = other.name
             }
@@ -2284,7 +2475,7 @@ extension SnapshotTests {
               }
             }
             fileprivate struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = ReminderWithList
+              public typealias SourceTable = ReminderWithList
               var reminderID: Reminder.ID?
               @StructuredQueries._ColumnCheck(String?.self)
               var reminderTitle: String?
@@ -2361,7 +2552,7 @@ extension SnapshotTests {
               self.reminderTitle = try decoder.decode() ?? nil
               self.remindersListTitle = try decoder.decode() ?? nil
             }
-            fileprivate nonisolated init(_ other: PrimaryTable) {
+            fileprivate nonisolated init(_ other: SourceTable) {
               self.reminderID = other.reminderID
               self.reminderTitle = other.reminderTitle
               self.remindersListTitle = other.remindersListTitle
@@ -2466,7 +2657,7 @@ extension SnapshotTests {
               }
             }
             fileprivate struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Metadata
+              public typealias SourceTable = Metadata
               @StructuredQueries._ColumnCheck(MetadataID?.self)
               var id: MetadataID?
               @StructuredQueries._ColumnCheck(Date?.self)
@@ -2535,7 +2726,7 @@ extension SnapshotTests {
               self.id = try decoder.decode() ?? nil
               self.userModificationDate = try decoder.decode() ?? nil
             }
-            fileprivate nonisolated init(_ other: PrimaryTable) {
+            fileprivate nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.userModificationDate = other.userModificationDate
             }
@@ -2632,7 +2823,7 @@ extension SnapshotTests {
               }
             }
             fileprivate struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Row
+              public typealias SourceTable = Row
               @StructuredQueries._ColumnCheck(UUID?.self)
               var id: UUID?
               var timestamps: Timestamps?
@@ -2700,7 +2891,7 @@ extension SnapshotTests {
               self.id = try decoder.decode() ?? nil
               self.timestamps = try decoder.decode() ?? nil
             }
-            fileprivate nonisolated init(_ other: PrimaryTable) {
+            fileprivate nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.timestamps = other.timestamps
             }
@@ -2817,7 +3008,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Place
+              public typealias SourceTable = Place
               @Column("id", primaryKey: true) @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @Column("latitude") @StructuredQueries._ColumnCheck(Double.self)
@@ -2908,7 +3099,7 @@ extension SnapshotTests {
               }
               self.latitude = latitude
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.latitude = other.latitude
               self.name = other.name
@@ -3020,7 +3211,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Item
+              public typealias SourceTable = Item
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @StructuredQueries._ColumnCheck(Int.self)
@@ -3102,7 +3293,7 @@ extension SnapshotTests {
               }
               self.quantity = quantity
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.quantity = other.quantity
               self.note = other.note
@@ -3217,7 +3408,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = User
+              public typealias SourceTable = User
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: /* TODO: UUID */ Int? // Primary key
               @StructuredQueries._ColumnCheck(String?.self)
@@ -3299,7 +3490,7 @@ extension SnapshotTests {
               }
               self.age = age
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.email = other.email
               self.age = other.age
@@ -3406,7 +3597,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = User
+              public typealias SourceTable = User
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @StructuredQueries._ColumnCheck(String.self)
@@ -3479,7 +3670,7 @@ extension SnapshotTests {
               }
               self.name = name
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.name = other.name
             }
@@ -3585,7 +3776,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = SyncUp
+              public typealias SourceTable = SyncUp
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @StructuredQueries._ColumnCheck(String.self)
@@ -3658,7 +3849,7 @@ extension SnapshotTests {
               }
               self.name = name
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.name = other.name
             }
@@ -3764,7 +3955,7 @@ extension SnapshotTests {
               }
             }
             struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Foo
+              public typealias SourceTable = Foo
               @StructuredQueries._ColumnCheck(Int?.self)
               var id: Int?
               @StructuredQueries._ColumnCheck(String.self)
@@ -3837,7 +4028,7 @@ extension SnapshotTests {
               }
               self.name = name
             }
-            nonisolated init(_ other: PrimaryTable) {
+            nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.name = other.name
             }
@@ -3943,7 +4134,7 @@ extension SnapshotTests {
               }
             }
             fileprivate struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = ReminderWithList
+              public typealias SourceTable = ReminderWithList
               var reminderID: Reminder.ID?
               @StructuredQueries._ColumnCheck(String.self)
               let reminderTitle: String
@@ -4028,7 +4219,7 @@ extension SnapshotTests {
               self.reminderTitle = reminderTitle
               self.remindersListTitle = remindersListTitle
             }
-            fileprivate nonisolated init(_ other: PrimaryTable) {
+            fileprivate nonisolated init(_ other: SourceTable) {
               self.reminderID = other.reminderID
               self.reminderTitle = other.reminderTitle
               self.remindersListTitle = other.remindersListTitle
@@ -4133,7 +4324,7 @@ extension SnapshotTests {
               }
             }
             fileprivate struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Metadata
+              public typealias SourceTable = Metadata
               @StructuredQueries._ColumnCheck(MetadataID?.self)
               var id: MetadataID?
               @StructuredQueries._ColumnCheck(Date.self)
@@ -4206,7 +4397,7 @@ extension SnapshotTests {
               }
               self.userModificationDate = userModificationDate
             }
-            fileprivate nonisolated init(_ other: PrimaryTable) {
+            fileprivate nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.userModificationDate = other.userModificationDate
             }
@@ -4303,7 +4494,7 @@ extension SnapshotTests {
               }
             }
             fileprivate struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-              public typealias PrimaryTable = Row
+              public typealias SourceTable = Row
               @StructuredQueries._ColumnCheck(UUID?.self)
               var id: UUID?
               var timestamps: Timestamps
@@ -4375,7 +4566,7 @@ extension SnapshotTests {
               }
               self.timestamps = timestamps
             }
-            fileprivate nonisolated init(_ other: PrimaryTable) {
+            fileprivate nonisolated init(_ other: SourceTable) {
               self.id = other.id
               self.timestamps = other.timestamps
             }

--- a/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
@@ -1375,7 +1375,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = User
+            public typealias SourceTable = User
             var id: ID<User, UUID>?
             var referrerID: ID<User, UUID>?
 
@@ -1442,7 +1442,7 @@ extension SnapshotTests {
             self.id = try decoder.decode(ID<User, UUID.BytesRepresentation>.self) ?? nil
             self.referrerID = try decoder.decode(ID<User, UUID.BytesRepresentation>.self) ?? nil
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.referrerID = other.referrerID
           }
@@ -1614,7 +1614,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = SyncUp
+            public typealias SourceTable = SyncUp
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
             @StructuredQueries._ColumnCheck(60 * 5)
@@ -1683,7 +1683,7 @@ extension SnapshotTests {
             self.id = try decoder.decode() ?? nil
             self.seconds = try decoder.decode() ?? 60 * 5
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.seconds = other.seconds
           }
@@ -1785,7 +1785,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = RemindersList
+            public typealias SourceTable = RemindersList
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
             var color = Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255)
@@ -1862,7 +1862,7 @@ extension SnapshotTests {
             self.color = try decoder.decode(Color.HexRepresentation.self) ?? Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255)
             self.name = try decoder.decode() ?? ""
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.color = other.color
             self.name = other.name
@@ -2922,7 +2922,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Foo
+            public typealias SourceTable = Foo
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
 
@@ -2982,7 +2982,7 @@ extension SnapshotTests {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.id = try decoder.decode() ?? nil
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
           }
         }
@@ -3121,7 +3121,7 @@ extension SnapshotTests {
             }
             self.id = id
           }
-          public nonisolated init(_ other: PrimaryTable) {
+          public nonisolated init(_ other: SourceTable) {
             self.id = other.id
           }
         }
@@ -3205,7 +3205,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Reminder
+            public typealias SourceTable = Reminder
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?
             @StructuredQueries._ColumnCheck(Swift.String.self)
@@ -3291,7 +3291,7 @@ extension SnapshotTests {
             self.date = try decoder.decode(Date.UnixTimeRepresentation.self) ?? nil
             self.priority = try decoder.decode() ?? nil
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.title = other.title
             self.date = other.date
@@ -3383,7 +3383,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Reminder
+            public typealias SourceTable = Reminder
             var id: UUID?
 
             public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
@@ -3442,7 +3442,7 @@ extension SnapshotTests {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.id = try decoder.decode(UUID.BytesRepresentation.self) ?? nil
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
           }
         }
@@ -3610,7 +3610,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = Reminder
+            public typealias SourceTable = Reminder
             @StructuredQueries._ColumnCheck(Int?.self)
             var id: Int?  // TODO: Migrate to UUID
             @StructuredQueries._ColumnCheck(Swift.String.self)
@@ -3679,7 +3679,7 @@ extension SnapshotTests {
             self.id = try decoder.decode() ?? nil
             self.title = try decoder.decode() ?? ""
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
             self.title = other.title
           }
@@ -3761,7 +3761,7 @@ extension SnapshotTests {
             }
           }
           struct Draft: StructuredQueriesCore.TableDraft, StructuredQueriesCore.PartialSelectStatement {
-            public typealias PrimaryTable = ReminderTag
+            public typealias SourceTable = ReminderTag
             var id: ReminderTagID?
 
             public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
@@ -3820,7 +3820,7 @@ extension SnapshotTests {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.id = try decoder.decode() ?? nil
           }
-          nonisolated init(_ other: PrimaryTable) {
+          nonisolated init(_ other: SourceTable) {
             self.id = other.id
           }
         }

--- a/Tests/StructuredQueriesTests/NonPrimaryKeyedDraftTests.swift
+++ b/Tests/StructuredQueriesTests/NonPrimaryKeyedDraftTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import InlineSnapshotTesting
+import StructuredQueries
+import StructuredQueriesTestSupport
+import Testing
+import _StructuredQueriesSQLite
+
+@Table
+struct Location {
+  @Column(lazyInitializable: true)
+  var latitude: Double
+  @Column(lazyInitializable: true)
+  var longitude: Double
+  var name: String
+}
+
+extension SnapshotTests {
+  @Suite struct NonPrimaryKeyedDraftTests {
+    func draftOfDraftIsNever() {
+      let _: Never.Type = Location.Draft.Draft.self
+    }
+
+    @Test func insertDraftWithUninitializedColumns() {
+      assertInlineSnapshot(
+        of: Location.insert { Location.Draft(name: "Home") },
+        as: .sql
+      ) {
+        """
+        INSERT INTO "locations"
+        ("latitude", "longitude", "name")
+        VALUES
+        (NULL, NULL, 'Home')
+        """
+      }
+    }
+
+    @Test func insertDraftFromRow() {
+      let location = Location(latitude: 1, longitude: 2, name: "Home")
+      assertInlineSnapshot(
+        of: Location.insert { Location.Draft(location) },
+        as: .sql
+      ) {
+        """
+        INSERT INTO "locations"
+        ("latitude", "longitude", "name")
+        VALUES
+        (1.0, 2.0, 'Home')
+        """
+      }
+    }
+
+    @Test func liveInsertLetsDatabaseFillUninitializedColumns() throws {
+      let db = try Database()
+      try db.execute(
+        #sql(
+          """
+          CREATE TABLE "locations" (
+            "latitude" REAL NOT NULL ON CONFLICT REPLACE DEFAULT 0,
+            "longitude" REAL NOT NULL ON CONFLICT REPLACE DEFAULT 0,
+            "name" TEXT NOT NULL
+          )
+          """
+        )
+      )
+      try db.execute(Location.insert { Location.Draft(name: "Home") })
+      let location = try #require(try db.execute(Location.all).first)
+      #expect(location.latitude == 0)
+      #expect(location.longitude == 0)
+      #expect(location.name == "Home")
+    }
+  }
+}


### PR DESCRIPTION
This expands on #300 by generalizing the generated `Draft` type to any table with lazy-initializable columns.

In the future we can simplify things further by no longer special-casing primary keys like `let id: UUID`, but that requires the `LazyInitializableByDefault` trait behavior to be the only behavior, so maybe in 1.0...