### PR TITLE
Better support for nested `@Table`/`@Selection`

### DIFF
--- a/Sources/StructuredQueries/Macros.swift
+++ b/Sources/StructuredQueries/Macros.swift
@@ -18,14 +18,8 @@ public import StructuredQueriesCore
     PrimaryKeyedTable,
     CasePathable,
     CasePathIterable,
-    names: named(From),
-    named(columns),
-    named(_columnWidth),
-    named(init(_:)),
-    named(init(decoder:)),
-    named(QueryValue),
-    named(schemaName),
-    named(tableName)
+    names: named(init(_:)),
+    named(init(decoder:))
   )
   @attached(
     member,
@@ -33,8 +27,14 @@ public import StructuredQueriesCore
     PartialSelectStatement,
     PrimaryKeyedTable,
     names: named(Draft),
+    named(From),
+    named(QueryValue),
     named(Selection),
     named(TableColumns),
+    named(_columnWidth),
+    named(columns),
+    named(schemaName),
+    named(tableName),
     named(AllCasePaths),
     named(allCasePaths),
     named(_$Element)
@@ -45,14 +45,8 @@ public import StructuredQueriesCore
     conformances: Table,
     PartialSelectStatement,
     PrimaryKeyedTable,
-    names: named(From),
-    named(columns),
-    named(_columnWidth),
-    named(init(_:)),
-    named(init(decoder:)),
-    named(QueryValue),
-    named(schemaName),
-    named(tableName)
+    names: named(init(_:)),
+    named(init(decoder:))
   )
   @attached(
     member,
@@ -60,8 +54,14 @@ public import StructuredQueriesCore
     PartialSelectStatement,
     PrimaryKeyedTable,
     names: named(Draft),
+    named(From),
+    named(QueryValue),
     named(Selection),
-    named(TableColumns)
+    named(TableColumns),
+    named(_columnWidth),
+    named(columns),
+    named(schemaName),
+    named(tableName)
   )
 #endif
 @attached(memberAttribute)
@@ -115,14 +115,8 @@ public macro Table(
     PrimaryKeyedTable,
     CasePathable,
     CasePathIterable,
-    names: named(From),
-    named(columns),
-    named(_columnWidth),
-    named(init(_:)),
-    named(init(decoder:)),
-    named(QueryValue),
-    named(schemaName),
-    named(tableName)
+    names: named(init(_:)),
+    named(init(decoder:))
   )
   @attached(
     member,
@@ -131,8 +125,14 @@ public macro Table(
     PartialSelectStatement,
     PrimaryKeyedTable,
     names: named(Draft),
+    named(From),
+    named(QueryValue),
     named(Selection),
     named(TableColumns),
+    named(_columnWidth),
+    named(columns),
+    named(schemaName),
+    named(tableName),
     named(AllCasePaths),
     named(allCasePaths),
     named(_$Element)
@@ -144,14 +144,8 @@ public macro Table(
     Table,
     PartialSelectStatement,
     PrimaryKeyedTable,
-    names: named(From),
-    named(columns),
-    named(_columnWidth),
-    named(init(_:)),
-    named(init(decoder:)),
-    named(QueryValue),
-    named(schemaName),
-    named(tableName)
+    names: named(init(_:)),
+    named(init(decoder:))
   )
   @attached(
     member,
@@ -160,8 +154,14 @@ public macro Table(
     PartialSelectStatement,
     PrimaryKeyedTable,
     names: named(Draft),
+    named(From),
+    named(QueryValue),
     named(Selection),
-    named(TableColumns)
+    named(TableColumns),
+    named(_columnWidth),
+    named(columns),
+    named(schemaName),
+    named(tableName)
   )
 #endif
 @attached(memberAttribute)

--- a/Sources/StructuredQueriesMacros/Internal/DeclGroupSyntax.swift
+++ b/Sources/StructuredQueriesMacros/Internal/DeclGroupSyntax.swift
@@ -44,3 +44,13 @@ extension DeclGroupSyntax {
     }
   }
 }
+
+extension SyntaxProtocol {
+  var declGroupAccessLevelModifier: DeclModifierSyntax? {
+    self.as(StructDeclSyntax.self)?.accessLevelModifier
+      ?? self.as(EnumDeclSyntax.self)?.accessLevelModifier
+      ?? self.as(ClassDeclSyntax.self)?.accessLevelModifier
+      ?? self.as(ActorDeclSyntax.self)?.accessLevelModifier
+      ?? self.as(ExtensionDeclSyntax.self)?.accessLevelModifier
+  }
+}

--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -52,7 +52,7 @@ extension TableMacro: ExtensionMacro {
     }
     guard
       declaration.isTableMacroSupported,
-      let declarationName = declaration.declarationName
+      declaration.declarationName != nil
     else {
       context.diagnose(
         Diagnostic(
@@ -75,7 +75,6 @@ extension TableMacro: ExtensionMacro {
 
     var allColumns: [TokenSyntax] = []
     var columnsProperties: [DeclSyntax] = []
-    var columnWidths: [ExprSyntax] = []
     var diagnostics: [Diagnostic] = []
 
     var draftTableType: TypeSyntax?
@@ -90,12 +89,6 @@ extension TableMacro: ExtensionMacro {
     let selfRewriter = SelfRewriter(
       selfEquivalent: type.as(IdentifierTypeSyntax.self)?.name ?? "QueryValue"
     )
-    var schemaName: ExprSyntax?
-    var tableName = ExprSyntax(
-      StringLiteralExprSyntax(
-        content: declarationName.trimmed.text.lowerCamelCased().pluralized()
-      )
-    )
     if case .argumentList(let arguments) = node.arguments {
       for argumentIndex in arguments.indices {
         let argument = arguments[argumentIndex]
@@ -104,16 +97,13 @@ extension TableMacro: ExtensionMacro {
           if node.attributeName.identifier == "_Draft" {
             let memberAccess = argument.expression.cast(MemberAccessExprSyntax.self)
             draftTableType = TypeSyntax("\(memberAccess.base!.trimmed)")
-          } else {
-            if !argument.expression.isNonEmptyStringLiteral {
-              diagnostics.append(
-                Diagnostic(
-                  node: argument.expression,
-                  message: MacroExpansionErrorMessage("Argument must be a non-empty string literal")
-                )
+          } else if !argument.expression.isNonEmptyStringLiteral {
+            diagnostics.append(
+              Diagnostic(
+                node: argument.expression,
+                message: MacroExpansionErrorMessage("Argument must be a non-empty string literal")
               )
-            }
-            tableName = argument.expression.trimmed
+            )
           }
 
         case .some(let label) where label.text == "schema":
@@ -125,7 +115,6 @@ extension TableMacro: ExtensionMacro {
               )
             )
           }
-          schemaName = argument.expression.trimmed
 
         case let argument?:
           fatalError("Unexpected argument: \(argument)")
@@ -356,11 +345,6 @@ extension TableMacro: ExtensionMacro {
           )
         }
 
-        columnWidths.append(
-          columnQueryValueType.map { "\($0)._columnWidth" as ExprSyntax }
-            ?? "\(moduleName)._columnWidth(\\QueryValue.\(identifier))"
-        )
-
         let defaultValue =
           binding.initializer?.value.rewritten(selfRewriter)
           ?? (columnQueryValueType?.isOptionalType == true
@@ -581,8 +565,6 @@ extension TableMacro: ExtensionMacro {
           }
         }
 
-        columnWidths.append("\(columnQueryValueType)._columnWidth")
-
         let defaultValue = parameter.defaultValue?.value.rewritten(selfRewriter)
         let tableColumnType =
           isColumnGroup
@@ -697,46 +679,11 @@ extension TableMacro: ExtensionMacro {
       return []
     }
 
-    var statics: [DeclSyntax] = []
-    var letSchemaName: DeclSyntax?
-    if let schemaName {
-      letSchemaName = """
-
-        public \(nonisolated)static let schemaName: Swift.String? = \(schemaName)
-        """
-    }
     if draftTableType == nil {
       conformances.append("\(moduleName).PartialSelectStatement")
     }
-    statics.append(contentsOf: [
-      """
-
-      public typealias QueryValue = Self
-      """,
-      """
-      public typealias From = Swift.Never
-      """,
-    ])
-    let columnWidth = """
-      var columnWidth = 0
-      columnWidth += \(columnWidths.map(\.description).joined(separator: "\ncolumnWidth += "))
-      return columnWidth
-      """
 
     var extensionMembers: [DeclSyntax] = []
-    if draftTableType == nil {
-      extensionMembers.append(contentsOf: statics)
-      extensionMembers.append(
-        "public \(nonisolated)static var columns: TableColumns { TableColumns() }"
-      )
-      extensionMembers.append(
-        "public \(nonisolated)static var _columnWidth: Int { \(raw: columnWidth) }"
-      )
-      extensionMembers.append("public \(nonisolated)static var tableName: String { \(tableName) }")
-      if let letSchemaName {
-        extensionMembers.append(letSchemaName)
-      }
-    }
     if let initDecoder {
       extensionMembers.append(initDecoder)
     }
@@ -808,6 +755,26 @@ extension TableMacro: MemberMacro {
       )?
     let selfRewriter = SelfRewriter(selfEquivalent: type.name)
     var selectionInitializers: [DeclSyntax] = []
+    var schemaName: ExprSyntax?
+    var tableName = ExprSyntax(
+      StringLiteralExprSyntax(
+        content: declarationName.trimmed.text.lowerCamelCased().pluralized()
+      )
+    )
+    if node.attributeName.identifier != "_Draft",
+      case .argumentList(let arguments) = node.arguments
+    {
+      for argument in arguments {
+        switch argument.label {
+        case nil:
+          tableName = argument.expression.trimmed
+        case .some(let label) where label.text == "schema":
+          schemaName = argument.expression.trimmed
+        default:
+          break
+        }
+      }
+    }
     if declaration.is(StructDeclSyntax.self) {
       for member in declaration.memberBlock.members {
         guard
@@ -1356,6 +1323,18 @@ extension TableMacro: MemberMacro {
 
       """
 
+    var tableMembers: [DeclSyntax] = []
+    if node.attributeName.identifier != "_Draft" {
+      tableMembers.append(
+        "public \(nonisolated)static var tableName: Swift.String { \(tableName) }"
+      )
+      if let schemaName {
+        tableMembers.append(
+          "public \(nonisolated)static let schemaName: Swift.String? = \(schemaName)"
+        )
+      }
+    }
+
     var members =
       [
         """
@@ -1385,12 +1364,12 @@ extension TableMacro: MemberMacro {
         draft,
       ]
       .compactMap { $0 }
-      + (node.attributeName.identifier == "_Draft"
-        ? typeAliases + [
-          "public \(nonisolated)static var columns: TableColumns { TableColumns() }",
-          "public \(nonisolated)static var _columnWidth: Swift.Int { \(raw: columnWidth) }",
-        ]
-        : [])
+      + typeAliases
+      + [
+        "public \(nonisolated)static var columns: TableColumns { TableColumns() }",
+        "public \(nonisolated)static var _columnWidth: Swift.Int { \(raw: columnWidth) }",
+      ]
+      + tableMembers
     #if CasePaths
       if declaration.is(EnumDeclSyntax.self) {
         members += try CasePathableMacro.expansion(

--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -1198,6 +1198,7 @@ extension TableMacro: MemberMacro {
           )
         }
         appendColumnProperty()
+        columnWidths.append("\(columnQueryValueType)._columnWidth")
         allColumns.append(
           (identifier, parameter.firstName ?? "_", columnQueryValueType, defaultValue?.trimmed)
         )
@@ -1234,14 +1235,23 @@ extension TableMacro: MemberMacro {
 
     var draft: DeclSyntax?
     if node.attributeName.identifier != "_Draft", primaryKey != nil || draftHasLazyColumn {
+      func isReducedVisibility(_ tokenKind: TokenKind?) -> Bool {
+        tokenKind == .keyword(.private) || tokenKind == .keyword(.fileprivate)
+      }
       let draftAccess: String
-      switch declaration.accessLevelModifier?.name.tokenKind {
-      case .keyword(.private), .keyword(.fileprivate):
+      if isReducedVisibility(declaration.accessLevelModifier?.name.tokenKind)
+        || context.lexicalContext.contains(where: {
+          isReducedVisibility($0.declGroupAccessLevelModifier?.name.tokenKind)
+        })
+      {
         draftAccess = "fileprivate "
-      case nil, .keyword(.internal):
-        draftAccess = ""
-      default:
-        draftAccess = "\(declaration.accessLevelModifier?.name.text ?? "") "
+      } else {
+        switch declaration.accessLevelModifier?.name.tokenKind {
+        case nil, .keyword(.internal):
+          draftAccess = ""
+        default:
+          draftAccess = "\(declaration.accessLevelModifier?.name.text ?? "") "
+        }
       }
       draft = """
 

--- a/Tests/StructuredQueriesMacrosTests/LazyInitializableTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/LazyInitializableTests.swift
@@ -141,6 +141,26 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            columnWidth += Double._columnWidth
+            columnWidth += Double._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "places"
+          }
         }
 
         nonisolated extension Draft {
@@ -157,21 +177,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Place: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            columnWidth += Double._columnWidth
-            columnWidth += Double._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "places"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             let latitude = try decoder.decode(\QueryValue.latitude)
@@ -315,6 +320,25 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            columnWidth += Double._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "places"
+          }
         }
 
         nonisolated extension Draft {
@@ -333,20 +357,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Place: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            columnWidth += Double._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "places"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             let latitude = try decoder.decode(\QueryValue.latitude)
@@ -485,6 +495,25 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            columnWidth += Date.ISO8601Representation._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "events"
+          }
         }
 
         nonisolated extension Draft {
@@ -499,20 +528,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Event: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            columnWidth += Date.ISO8601Representation._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "events"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             let startsAt = try decoder.decode(Date.ISO8601Representation.self)
@@ -651,6 +666,25 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            columnWidth += Coordinate._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "places"
+          }
         }
 
         nonisolated extension Draft {
@@ -665,20 +699,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Place: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            columnWidth += Coordinate._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "places"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             let coordinate = try decoder.decode(\QueryValue.coordinate)
@@ -817,6 +837,25 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            columnWidth += CKRecord?.SystemFieldsRepresentation._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "records"
+          }
         }
 
         nonisolated extension Draft {
@@ -835,20 +874,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Record: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            columnWidth += CKRecord?.SystemFieldsRepresentation._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "records"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             let systemFields = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
@@ -1049,6 +1074,27 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            columnWidth += String?._columnWidth
+            columnWidth += Int?._columnWidth
+            columnWidth += Double._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "records"
+          }
         }
 
         nonisolated extension Draft {
@@ -1067,22 +1113,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Record: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            columnWidth += String?._columnWidth
-            columnWidth += Int?._columnWidth
-            columnWidth += Double._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "records"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             self.a = try decoder.decode() ?? nil
@@ -1236,6 +1266,26 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Double._columnWidth
+            columnWidth += Double._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "locations"
+          }
         }
 
         nonisolated extension Draft {
@@ -1256,21 +1306,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Location: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Double._columnWidth
-            columnWidth += Double._columnWidth
-            columnWidth += String._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "locations"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let latitude = try decoder.decode(\QueryValue.latitude)
             let longitude = try decoder.decode(\QueryValue.longitude)
@@ -3086,6 +3121,27 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += Double._columnWidth
+              columnWidth += Swift.String._columnWidth
+              columnWidth += String?._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "places"
+            }
           }
 
           nonisolated extension Draft {
@@ -3108,22 +3164,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Place: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += Double._columnWidth
-              columnWidth += Swift.String._columnWidth
-              columnWidth += String?._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "places"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let latitude = try decoder.decode(\QueryValue.latitude)
@@ -3281,6 +3321,26 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += Int._columnWidth
+              columnWidth += String?._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "items"
+            }
           }
 
           nonisolated extension Draft {
@@ -3301,21 +3361,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Item: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += Int._columnWidth
-              columnWidth += String?._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "items"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let quantity = try decoder.decode(\QueryValue.quantity)
@@ -3478,6 +3523,26 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += String?._columnWidth
+              columnWidth += Int._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "users"
+            }
           }
 
           nonisolated extension Draft {
@@ -3498,21 +3563,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += String?._columnWidth
-              columnWidth += Int._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "users"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               self.email = try decoder.decode() ?? ""  // TODO: Should this be non-optional?
@@ -3659,6 +3709,26 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += String._columnWidth
+              columnWidth += Int._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "users"
+            }
           }
 
           nonisolated extension Draft {
@@ -3677,21 +3747,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += String._columnWidth
-              columnWidth += Int._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "users"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let name = try decoder.decode(\QueryValue.name)
@@ -3838,6 +3893,25 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += String._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "syncUps"
+            }
           }
 
           nonisolated extension Draft {
@@ -3856,20 +3930,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += String._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "syncUps"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let name = try decoder.decode(\QueryValue.name)
@@ -4017,6 +4077,25 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += String._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "foos"
+            }
           }
 
           nonisolated extension Draft {
@@ -4035,20 +4114,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += String._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "foos"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let name = try decoder.decode(\QueryValue.name)
@@ -4203,6 +4268,26 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Reminder.ID._columnWidth
+              columnWidth += String._columnWidth
+              columnWidth += String._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "reminderWithLists"
+            }
           }
 
           nonisolated extension Draft {
@@ -4227,21 +4312,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension ReminderWithList: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Reminder.ID._columnWidth
-              columnWidth += String._columnWidth
-              columnWidth += String._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "reminderWithLists"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let reminderID = try decoder.decode(\QueryValue.reminderID)
               let reminderTitle = try decoder.decode(\QueryValue.reminderTitle)
@@ -4386,6 +4456,25 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += MetadataID._columnWidth
+              columnWidth += Date._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "metadatas"
+            }
           }
 
           nonisolated extension Draft {
@@ -4404,20 +4493,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Metadata: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += MetadataID._columnWidth
-              columnWidth += Date._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "metadatas"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let userModificationDate = try decoder.decode(\QueryValue.userModificationDate)
@@ -4555,6 +4630,25 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += UUID._columnWidth
+              columnWidth += Timestamps._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "rows"
+            }
           }
 
           nonisolated extension Draft {
@@ -4573,20 +4667,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Row: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += UUID._columnWidth
-              columnWidth += Timestamps._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "rows"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let timestamps = try decoder.decode(\QueryValue.timestamps)

--- a/Tests/StructuredQueriesMacrosTests/LazyInitializableTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/LazyInitializableTests.swift
@@ -1486,6 +1486,27 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += Double._columnWidth
+              columnWidth += Swift.String._columnWidth
+              columnWidth += String?._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "places"
+            }
           }
 
           nonisolated extension Draft {
@@ -1504,22 +1525,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Place: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += Double._columnWidth
-              columnWidth += Swift.String._columnWidth
-              columnWidth += String?._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "places"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let latitude = try decoder.decode(\QueryValue.latitude)
@@ -1677,6 +1682,26 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += Int._columnWidth
+              columnWidth += String?._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "items"
+            }
           }
 
           nonisolated extension Draft {
@@ -1693,21 +1718,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Item: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += Int._columnWidth
-              columnWidth += String?._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "items"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let quantity = try decoder.decode(\QueryValue.quantity)
@@ -1870,6 +1880,26 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += String?._columnWidth
+              columnWidth += Int._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "users"
+            }
           }
 
           nonisolated extension Draft {
@@ -1886,21 +1916,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += String?._columnWidth
-              columnWidth += Int._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "users"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               self.email = try decoder.decode() ?? ""  // TODO: Should this be non-optional?
@@ -2047,6 +2062,26 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += String._columnWidth
+              columnWidth += Int._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "users"
+            }
           }
 
           nonisolated extension Draft {
@@ -2061,21 +2096,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += String._columnWidth
-              columnWidth += Int._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "users"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let name = try decoder.decode(\QueryValue.name)
@@ -2222,6 +2242,25 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += String._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "syncUps"
+            }
           }
 
           nonisolated extension Draft {
@@ -2236,20 +2275,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += String._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "syncUps"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let name = try decoder.decode(\QueryValue.name)
@@ -2397,6 +2422,25 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Int._columnWidth
+              columnWidth += String._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "foos"
+            }
           }
 
           nonisolated extension Draft {
@@ -2411,20 +2455,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Int._columnWidth
-              columnWidth += String._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "foos"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let name = try decoder.decode(\QueryValue.name)
@@ -2579,6 +2609,26 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += Reminder.ID._columnWidth
+              columnWidth += String._columnWidth
+              columnWidth += String._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "reminderWithLists"
+            }
           }
 
           nonisolated extension Draft {
@@ -2595,21 +2645,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension ReminderWithList: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += Reminder.ID._columnWidth
-              columnWidth += String._columnWidth
-              columnWidth += String._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "reminderWithLists"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let reminderID = try decoder.decode(\QueryValue.reminderID)
               let reminderTitle = try decoder.decode(\QueryValue.reminderTitle)
@@ -2754,6 +2789,25 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += MetadataID._columnWidth
+              columnWidth += Date._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "metadatas"
+            }
           }
 
           nonisolated extension Draft {
@@ -2768,20 +2822,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Metadata: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += MetadataID._columnWidth
-              columnWidth += Date._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "metadatas"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let userModificationDate = try decoder.decode(\QueryValue.userModificationDate)
@@ -2919,6 +2959,25 @@ extension SnapshotTests {
                 return columnWidth
               }
             }
+
+            public typealias QueryValue = Self
+
+            public typealias From = Swift.Never
+
+            public nonisolated static var columns: TableColumns {
+              TableColumns()
+            }
+
+            public nonisolated static var _columnWidth: Swift.Int {
+              var columnWidth = 0
+              columnWidth += UUID._columnWidth
+              columnWidth += Timestamps._columnWidth
+              return columnWidth
+            }
+
+            public nonisolated static var tableName: Swift.String {
+              "rows"
+            }
           }
 
           nonisolated extension Draft {
@@ -2933,20 +2992,6 @@ extension SnapshotTests {
           }
 
           nonisolated extension Row: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-            public typealias QueryValue = Self
-            public typealias From = Swift.Never
-            public nonisolated static var columns: TableColumns {
-              TableColumns()
-            }
-            public nonisolated static var _columnWidth: Int {
-              var columnWidth = 0
-              columnWidth += UUID._columnWidth
-              columnWidth += Timestamps._columnWidth
-              return columnWidth
-            }
-            public nonisolated static var tableName: String {
-              "rows"
-            }
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
               let id = try decoder.decode(\QueryValue.id)
               let timestamps = try decoder.decode(\QueryValue.timestamps)

--- a/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
@@ -54,22 +54,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Int._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(\QueryValue.bar)
             guard let bar else {
@@ -131,22 +136,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore._Selection, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Int._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore._Selection, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(\QueryValue.bar)
             guard let bar else {
@@ -246,22 +256,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Int._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foo"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(\QueryValue.bar)
             guard let bar else {
@@ -363,23 +378,29 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Bar: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Int._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "bar"
           }
+
           public nonisolated static let schemaName: Swift.String? = "foo"
+        }
+
+        nonisolated extension Bar: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let baz = try decoder.decode(\QueryValue.baz)
             guard let baz else {
@@ -505,15 +526,16 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Swift.Bool._columnWidth
             columnWidth += Swift.Int._columnWidth
@@ -521,9 +543,13 @@ extension SnapshotTests {
             columnWidth += Swift.String._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.c1 = try decoder.decode() ?? true
             self.c2 = try decoder.decode() ?? 1
@@ -584,22 +610,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Int._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(\QueryValue.bar)
             guard let bar else {
@@ -705,22 +736,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Date.UnixTimeRepresentation._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(Date.UnixTimeRepresentation.self)
             guard let bar else {
@@ -788,23 +824,28 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += String._columnWidth
             columnWidth += String._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "users"
           }
+        }
+
+        nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let name = try decoder.decode(\QueryValue.name)
             let generated = try decoder.decode(\QueryValue.generated)
@@ -896,23 +937,28 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += String._columnWidth
             columnWidth += String._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "users"
           }
+        }
+
+        nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let name = try decoder.decode(\QueryValue.name)
             let generated = try decoder.decode(\QueryValue.generated)
@@ -981,22 +1027,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Int._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(\QueryValue.bar)
             guard let bar else {
@@ -1060,22 +1111,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Int._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(\QueryValue.bar)
             guard let bar else {
@@ -1137,22 +1193,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Int._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let `bar` = try decoder.decode(\QueryValue.`bar`)
             guard let `bar` else {
@@ -1214,22 +1275,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += ID<Foo>._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let bar = try decoder.decode(\QueryValue.bar)
             guard let bar else {
@@ -1291,22 +1357,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += StructuredQueriesCore._columnWidth(\QueryValue.bar)
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "foos"
           }
+        }
+
+        nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.bar = try decoder.decode() ?? ID<Foo>()
           }
@@ -1435,6 +1506,25 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += ID<User, UUID.BytesRepresentation>._columnWidth
+            columnWidth += ID<User, UUID.BytesRepresentation>?._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "users"
+          }
         }
 
         nonisolated extension Draft {
@@ -1449,20 +1539,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += ID<User, UUID.BytesRepresentation>._columnWidth
-            columnWidth += ID<User, UUID.BytesRepresentation>?._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "users"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(ID<User, UUID.BytesRepresentation>.self)
             self.referrerID = try decoder.decode(ID<User, UUID.BytesRepresentation>.self) ?? nil
@@ -1527,22 +1603,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += String._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "syncUps"
           }
+        }
+
+        nonisolated extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let name = try decoder.decode(\QueryValue.name)
             guard let name else {
@@ -1676,6 +1757,25 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            columnWidth += StructuredQueriesCore._columnWidth(\QueryValue.seconds)
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "syncUps"
+          }
         }
 
         nonisolated extension Draft {
@@ -1690,20 +1790,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            columnWidth += StructuredQueriesCore._columnWidth(\QueryValue.seconds)
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "syncUps"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             self.seconds = try decoder.decode() ?? 60 * 5
@@ -1854,6 +1940,26 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            columnWidth += Color.HexRepresentation._columnWidth
+            columnWidth += Swift.String._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "remindersLists"
+          }
         }
 
         nonisolated extension Draft {
@@ -1870,21 +1976,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension RemindersList: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            columnWidth += Color.HexRepresentation._columnWidth
-            columnWidth += Swift.String._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "remindersLists"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             self.color = try decoder.decode(Color.HexRepresentation.self) ?? Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255)
@@ -1971,22 +2062,27 @@ extension SnapshotTests {
             self.allColumns = allColumns
           }
         }
-      }
 
-      nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
         public typealias QueryValue = Self
+
         public typealias From = Swift.Never
+
         public nonisolated static var columns: TableColumns {
           TableColumns()
         }
-        public nonisolated static var _columnWidth: Int {
+
+        public nonisolated static var _columnWidth: Swift.Int {
           var columnWidth = 0
           columnWidth += String._columnWidth
           return columnWidth
         }
-        public nonisolated static var tableName: String {
+
+        public nonisolated static var tableName: Swift.String {
           "foos"
         }
+      }
+
+      nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
         public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
           let name = try decoder.decode(\QueryValue.name)
           guard let name else {
@@ -2056,23 +2152,28 @@ extension SnapshotTests {
             self.allColumns = allColumns
           }
         }
-      }
 
-      nonisolated extension RemindersListAliasAndReminderCount: StructuredQueriesCore.Table, StructuredQueriesCore._Selection, StructuredQueriesCore.PartialSelectStatement {
         public typealias QueryValue = Self
+
         public typealias From = Swift.Never
+
         public nonisolated static var columns: TableColumns {
           TableColumns()
         }
-        public nonisolated static var _columnWidth: Int {
+
+        public nonisolated static var _columnWidth: Swift.Int {
           var columnWidth = 0
           columnWidth += TableAlias<RemindersList, RL>._columnWidth
           columnWidth += Int._columnWidth
           return columnWidth
         }
-        public nonisolated static var tableName: String {
+
+        public nonisolated static var tableName: Swift.String {
           "remindersListAliasAndReminderCounts"
         }
+      }
+
+      nonisolated extension RemindersListAliasAndReminderCount: StructuredQueriesCore.Table, StructuredQueriesCore._Selection, StructuredQueriesCore.PartialSelectStatement {
         public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
           let remindersList = try decoder.decode(TableAlias<RemindersList, RL>.self)
           let remindersCount = try decoder.decode(\QueryValue.remindersCount)
@@ -2976,6 +3077,24 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "foos"
+          }
         }
 
         nonisolated extension Draft {
@@ -2988,19 +3107,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "foos"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             guard let id else {
@@ -3282,6 +3388,27 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int._columnWidth
+            columnWidth += Swift.String._columnWidth
+            columnWidth += Date.UnixTimeRepresentation?._columnWidth
+            columnWidth += Priority?._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "reminders"
+          }
         }
 
         nonisolated extension Draft {
@@ -3300,22 +3427,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int._columnWidth
-            columnWidth += Swift.String._columnWidth
-            columnWidth += Date.UnixTimeRepresentation?._columnWidth
-            columnWidth += Priority?._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "reminders"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             self.title = try decoder.decode() ?? ""
@@ -3436,6 +3547,24 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += UUID.BytesRepresentation._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "reminders"
+          }
         }
 
         nonisolated extension Draft {
@@ -3448,19 +3577,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += UUID.BytesRepresentation._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "reminders"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(UUID.BytesRepresentation.self)
             guard let id else {
@@ -3522,22 +3638,27 @@ extension SnapshotTests {
               self.allColumns = allColumns
             }
           }
-        }
 
-        nonisolated extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public typealias QueryValue = Self
+
           public typealias From = Swift.Never
+
           public nonisolated static var columns: TableColumns {
             TableColumns()
           }
-          public nonisolated static var _columnWidth: Int {
+
+          public nonisolated static var _columnWidth: Swift.Int {
             var columnWidth = 0
             columnWidth += Int._columnWidth
             return columnWidth
           }
-          public nonisolated static var tableName: String {
+
+          public nonisolated static var tableName: Swift.String {
             "reminders"
           }
+        }
+
+        nonisolated extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             guard let id else {
@@ -3672,6 +3793,25 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Int?._columnWidth
+            columnWidth += Swift.String._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "reminders"
+          }
         }
 
         nonisolated extension Draft {
@@ -3686,20 +3826,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Int?._columnWidth
-            columnWidth += Swift.String._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "reminders"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             self.id = try decoder.decode() ?? nil
             self.title = try decoder.decode() ?? ""
@@ -3814,6 +3940,24 @@ extension SnapshotTests {
               return columnWidth
             }
           }
+
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += ReminderTagID._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "remindersTags"
+          }
         }
 
         nonisolated extension Draft {
@@ -3826,19 +3970,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension ReminderTag: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += ReminderTagID._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "remindersTags"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let id = try decoder.decode(\QueryValue.id)
             guard let id else {

--- a/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
@@ -2256,6 +2256,25 @@ extension SnapshotTests {
             }
           }
 
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Photo._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "posts"
+          }
+
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
             public subscript(root: Post) -> CasePaths.PartialCaseKeyPath<Post> {
               if root.is(\.photo) {
@@ -2296,20 +2315,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Photo._columnWidth
-            columnWidth += String._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "posts"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let photo = try decoder.decode(Photo.self)
             let note = try decoder.decode(String.self)
@@ -2392,6 +2397,25 @@ extension SnapshotTests {
             }
           }
 
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Photo._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "posts"
+          }
+
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
             public subscript(root: Post) -> CasePaths.PartialCaseKeyPath<Post> {
               if root.is(\.photo) {
@@ -2432,20 +2456,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Photo._columnWidth
-            columnWidth += String._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "posts"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let photo = try decoder.decode(Photo.self)
             let note = try decoder.decode(String.self)
@@ -2527,6 +2537,25 @@ extension SnapshotTests {
             }
           }
 
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Photo._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "posts"
+          }
+
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
             public subscript(root: Post) -> CasePaths.PartialCaseKeyPath<Post> {
               if root.is(\.photo) {
@@ -2567,20 +2596,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Photo._columnWidth
-            columnWidth += String._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "posts"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let photo = try decoder.decode(Photo.self)
             let note = try decoder.decode(String.self)
@@ -2663,6 +2678,25 @@ extension SnapshotTests {
             }
           }
 
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Photo._columnWidth
+            columnWidth += String._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "posts"
+          }
+
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
             public subscript(root: Post) -> CasePaths.PartialCaseKeyPath<Post> {
               if root.is(\.photo) {
@@ -2703,20 +2737,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Photo._columnWidth
-            columnWidth += String._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "posts"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let photo = try decoder.decode(Photo.self)
             let note = try decoder.decode(String.self)
@@ -2786,6 +2806,24 @@ extension SnapshotTests {
             }
           }
 
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += String._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "posts"
+          }
+
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
             public subscript(root: Post) -> CasePaths.PartialCaseKeyPath<Post> {
               if root.is(\.note) {
@@ -2814,19 +2852,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += String._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "posts"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let note = try decoder.decode(String.self)
             if let note {
@@ -2893,6 +2918,24 @@ extension SnapshotTests {
             }
           }
 
+          public typealias QueryValue = Self
+
+          public typealias From = Swift.Never
+
+          public nonisolated static var columns: TableColumns {
+            TableColumns()
+          }
+
+          public nonisolated static var _columnWidth: Swift.Int {
+            var columnWidth = 0
+            columnWidth += Date.UnixTimeRepresentation._columnWidth
+            return columnWidth
+          }
+
+          public nonisolated static var tableName: Swift.String {
+            "posts"
+          }
+
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
             public subscript(root: Post) -> CasePaths.PartialCaseKeyPath<Post> {
               if root.is(\.timestamp) {
@@ -2921,19 +2964,6 @@ extension SnapshotTests {
         }
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
-          public typealias QueryValue = Self
-          public typealias From = Swift.Never
-          public nonisolated static var columns: TableColumns {
-            TableColumns()
-          }
-          public nonisolated static var _columnWidth: Int {
-            var columnWidth = 0
-            columnWidth += Date.UnixTimeRepresentation._columnWidth
-            return columnWidth
-          }
-          public nonisolated static var tableName: String {
-            "posts"
-          }
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
             let timestamp = try decoder.decode(Date.UnixTimeRepresentation.self)
             if let timestamp {

--- a/Tests/StructuredQueriesTests/CompileTimeTests.swift
+++ b/Tests/StructuredQueriesTests/CompileTimeTests.swift
@@ -95,3 +95,14 @@ private func functionWithLotsOfArguments(
   a12: Foo?
 ) {
 }
+
+// NB: Nested access control mismatch
+@Table
+fileprivate struct Item {
+  @Selection
+  struct Group {
+    var a: Int
+    var b: Int
+  }
+  var group: Group?
+}


### PR DESCRIPTION
We still had some special-casing for `@_Draft` that generated members rather than defining the in extensions, which allows things like `public` to be applied more easily and avoid access control compiler errors, so let's apply the fix more broadly.