### PR TITLE
Deprecate "Swifty" APIs

### DIFF
--- a/Sources/StructuredQueriesCore/Operators.swift
+++ b/Sources/StructuredQueriesCore/Operators.swift
@@ -100,7 +100,9 @@ extension QueryExpression where QueryValue: QueryRepresentable {
   }
 
   @available(
-    *, unavailable, message: "Use 'neq' or (or 'isNot') instead."
+    *,
+    unavailable,
+    message: "Use 'neq' or (or 'isNot') instead."
   )
   public static func != (
     lhs: Self,
@@ -110,7 +112,9 @@ extension QueryExpression where QueryValue: QueryRepresentable {
   }
 
   @available(
-    *, unavailable, message: "Use 'neq' or (or 'isNot') instead."
+    *,
+    unavailable,
+    message: "Use 'neq' or (or 'isNot') instead."
   )
   public static func != (
     lhs: Self,
@@ -120,7 +124,9 @@ extension QueryExpression where QueryValue: QueryRepresentable {
   }
 
   @available(
-    *, unavailable, message: "Use 'neq' or (or 'isNot') instead."
+    *,
+    unavailable,
+    message: "Use 'neq' or (or 'isNot') instead."
   )
   public static func != (
     lhs: Self,
@@ -712,6 +718,7 @@ extension QueryExpression where QueryValue == String {
   ///
   /// - Parameter other: A string expression describing the prefix.
   /// - Returns: A predicate expression.
+  @available(*, deprecated, message: "Prefer 'like(\"\\(other)%\")' instead")
   public func hasPrefix(_ other: some StringProtocol) -> some QueryExpression<Bool> {
     like("\(other)%")
   }
@@ -726,6 +733,7 @@ extension QueryExpression where QueryValue == String {
   ///
   /// - Parameter other: A string expression describing the suffix.
   /// - Returns: A predicate expression.
+  @available(*, deprecated, message: "Prefer 'like(\"%\\(other)\")' instead")
   public func hasSuffix(_ other: some StringProtocol) -> some QueryExpression<Bool> {
     like("%\(other)")
   }
@@ -741,8 +749,9 @@ extension QueryExpression where QueryValue == String {
   /// - Parameter other: A string expression describing the infix.
   /// - Returns: A predicate expression.
   @_disfavoredOverload
+  @available(*, deprecated, message: "Prefer 'like(\"%\\(other)%\")' instead")
   public func contains(_ other: some StringProtocol) -> some QueryExpression<Bool> {
-    like("%\(other)%")
+    return like("%\(other)%")
   }
 }
 
@@ -853,6 +862,7 @@ extension Sequence where Element: QueryBindable {
   ///
   /// - Parameter element: An element.
   /// - Returns: A predicate expression indicating whether the expression is in this sequence
+  @available(*, deprecated, message: "Prefer 'element.in(self)' instead")
   public func contains(
     _ element: some QueryExpression<Element.QueryValue>
   ) -> some QueryExpression<Bool> {
@@ -869,6 +879,11 @@ extension ClosedRange where Bound: QueryBindable {
   /// - Parameter element: An element.
   /// - Returns: A predicate expression indicating whether the given element is between this range's
   ///   bounds.
+  @available(
+    *,
+    deprecated,
+    message: "Prefer 'element.between(lowerBound, and: upperBound)' instead"
+  )
   public func contains(
     _ element: some QueryExpression<Bound.QueryValue>
   ) -> some QueryExpression<Bool> {
@@ -883,6 +898,7 @@ extension Statement where QueryValue: QueryBindable {
   ///
   /// - Parameter element: An element.
   /// - Returns: A predicate expression indicating whether this expression is in the given subquery.
+  @available(*, deprecated, message: "Prefer 'element.in(self)' instead")
   public func contains(
     _ element: some QueryExpression<QueryValue>
   ) -> some QueryExpression<Bool> {

--- a/Sources/StructuredQueriesCore/Operators.swift
+++ b/Sources/StructuredQueriesCore/Operators.swift
@@ -114,7 +114,7 @@ extension QueryExpression where QueryValue: QueryRepresentable {
   @available(
     *,
     unavailable,
-    message: "Use 'neq' or (or 'isNot') instead."
+    message: "Use 'neq' or 'isNot' instead."
   )
   public static func != (
     lhs: Self,

--- a/Sources/StructuredQueriesCore/Operators.swift
+++ b/Sources/StructuredQueriesCore/Operators.swift
@@ -126,7 +126,7 @@ extension QueryExpression where QueryValue: QueryRepresentable {
   @available(
     *,
     unavailable,
-    message: "Use 'neq' or (or 'isNot') instead."
+    message: "Use 'neq' or 'isNot' instead."
   )
   public static func != (
     lhs: Self,

--- a/Sources/StructuredQueriesCore/Operators.swift
+++ b/Sources/StructuredQueriesCore/Operators.swift
@@ -102,7 +102,7 @@ extension QueryExpression where QueryValue: QueryRepresentable {
   @available(
     *,
     unavailable,
-    message: "Use 'neq' or (or 'isNot') instead."
+    message: "Use 'neq' or 'isNot' instead."
   )
   public static func != (
     lhs: Self,

--- a/Tests/StructuredQueriesTests/CommonTableExpressionTests.swift
+++ b/Tests/StructuredQueriesTests/CommonTableExpressionTests.swift
@@ -68,7 +68,7 @@ extension SnapshotTests {
             .select { IncompleteReminder.Columns(isFlagged: $0.isFlagged, title: $0.title) }
         } query: {
           IncompleteReminder
-            .where { $0.title.collate(.nocase).contains("groceries") }
+            .where { $0.title.collate(.nocase).like("%groceries%") }
         }
       ) {
         """
@@ -336,7 +336,7 @@ extension SnapshotTests {
             .select { IncompleteReminder.Columns(isFlagged: $0.isFlagged, title: $0.title) }
         } query: {
           IncompleteReminder
-            .where { $0.title.collate(.nocase).contains("groceries") }
+            .where { $0.title.collate(.nocase).like("%groceries%") }
             .select { $0.isFlagged }
         }
       ) {

--- a/Tests/StructuredQueriesTests/OperatorsTests.swift
+++ b/Tests/StructuredQueriesTests/OperatorsTests.swift
@@ -231,6 +231,27 @@ extension SnapshotTests {
         ("rows"."string" LIKE 'a%' ESCAPE '\')
         """#
       }
+      assertInlineSnapshot(of: Row.update { $0.string += "!" }, as: .sql) {
+        """
+        UPDATE "rows"
+        SET "string" = ("rows"."string") || ('!')
+        """
+      }
+      assertInlineSnapshot(of: Row.update { $0.string.append("!") }, as: .sql) {
+        """
+        UPDATE "rows"
+        SET "string" = ("rows"."string") || ('!')
+        """
+      }
+      assertInlineSnapshot(of: Row.update { $0.string.append(contentsOf: "!") }, as: .sql) {
+        """
+        UPDATE "rows"
+        SET "string" = ("rows"."string") || ('!')
+        """
+      }
+    }
+    @available(*, deprecated)
+    @Test func stringDeprecations() {
       assertInlineSnapshot(of: Row.columns.string.hasPrefix("a"), as: .sql) {
         """
         ("rows"."string" LIKE 'a%')
@@ -249,24 +270,6 @@ extension SnapshotTests {
       assertInlineSnapshot(of: Row.columns.string.contains("a"[...]), as: .sql) {
         """
         ("rows"."string" LIKE '%a%')
-        """
-      }
-      assertInlineSnapshot(of: Row.update { $0.string += "!" }, as: .sql) {
-        """
-        UPDATE "rows"
-        SET "string" = ("rows"."string") || ('!')
-        """
-      }
-      assertInlineSnapshot(of: Row.update { $0.string.append("!") }, as: .sql) {
-        """
-        UPDATE "rows"
-        SET "string" = ("rows"."string") || ('!')
-        """
-      }
-      assertInlineSnapshot(of: Row.update { $0.string.append(contentsOf: "!") }, as: .sql) {
-        """
-        UPDATE "rows"
-        SET "string" = ("rows"."string") || ('!')
         """
       }
       assertInlineSnapshot(
@@ -297,6 +300,10 @@ extension SnapshotTests {
         FROM "rows"))
         """
       }
+    }
+
+    @available(*, deprecated)
+    @Test func collectionContains() {
       assertInlineSnapshot(
         of: [1, 2, 3].contains(Row.columns.c),
         as: .sql
@@ -316,6 +323,7 @@ extension SnapshotTests {
       }
     }
 
+    @available(*, deprecated)
     @Test func rangeContains() async throws {
       assertInlineSnapshot(
         of: (0...10).contains(Row.columns.c),
@@ -444,6 +452,7 @@ extension SnapshotTests {
       }
     }
 
+    @available(*, deprecated)
     @Test func containsCollectionElement() {
       assertQuery(
         Reminder.select { $0.id }.where { [1, 2].contains($0.id) }

--- a/Tests/StructuredQueriesTests/Support/Schema.swift
+++ b/Tests/StructuredQueriesTests/Support/Schema.swift
@@ -31,8 +31,8 @@ struct Reminder: Codable, Equatable, Identifiable {
   var updatedAt: Date = Date(timeIntervalSinceReferenceDate: 1_234_567_890)
   static func searching(_ text: String) -> Where<Reminder> {
     Self.where {
-      $0.title.collate(.nocase).contains(text)
-        || $0.notes.collate(.nocase).contains(text)
+      $0.title.collate(.nocase).like("%\(text)%")
+        || $0.notes.collate(.nocase).like("%\(text)%")
     }
   }
 }

--- a/Tests/StructuredQueriesTests/WhereTests.swift
+++ b/Tests/StructuredQueriesTests/WhereTests.swift
@@ -239,7 +239,7 @@ extension SnapshotTests {
       assertQuery(
         RemindersList.where {
           for term in terms {
-            $0.title.contains(term)
+            $0.title.like("%\(term)%")
           }
         }
       ) {


### PR DESCRIPTION
We have a few core APIs that mimic the underlying Swift API, but in general we prefer our APIs to be as close to SQL as possible, so let's deprecate ambiguous things like `contains` for the equivalent `like` and `in` APIs.