### PR TITLE
Address regression in drafts that reference nested types

### DIFF
--- a/Sources/StructuredQueriesCore/ColumnGroup.swift
+++ b/Sources/StructuredQueriesCore/ColumnGroup.swift
@@ -11,9 +11,15 @@ where Values.QueryOutput: Table {
 
   public typealias QueryValue = Values
 
+  public let defaultValue: Values.QueryOutput?
+
   public let keyPath: KeyPath<Root, Values.QueryOutput>
 
-  public init(keyPath: KeyPath<Root, Values.QueryOutput>) {
+  public init(
+    keyPath: KeyPath<Root, Values.QueryOutput>,
+    default defaultValue: Values.QueryOutput? = nil
+  ) {
+    self.defaultValue = defaultValue
     self.keyPath = keyPath
   }
 
@@ -48,7 +54,8 @@ where Values.QueryOutput: Table {
   ) -> ColumnGroup<Root, Member> {
     let column = Values.columns[keyPath: keyPath]
     return ColumnGroup<Root, Member>(
-      keyPath: self.keyPath.appending(path: column.keyPath)
+      keyPath: self.keyPath.appending(path: column.keyPath),
+      default: column.defaultValue
     )
   }
 

--- a/Sources/StructuredQueriesCore/Optional.swift
+++ b/Sources/StructuredQueriesCore/Optional.swift
@@ -209,6 +209,10 @@ where Wrapped.TableColumns: PrimaryKeyedTableDefinition {
       Wrapped.columns.primaryKey._names
     }
 
+    public var defaultValue: Wrapped.PrimaryKey.QueryOutput?? {
+      Wrapped.columns.primaryKey.defaultValue
+    }
+
     public var keyPath: KeyPath<Wrapped?, Wrapped.PrimaryKey.QueryOutput?> {
       \.[member: \Wrapped.PrimaryKey.self, column: Wrapped.columns.primaryKey.keyPath]
     }
@@ -227,10 +231,6 @@ extension Optional.TableColumns.PrimaryColumn: TableColumnExpression
 where Wrapped.TableColumns.PrimaryColumn: TableColumnExpression {
   public var name: String {
     Wrapped.columns.primaryKey.name
-  }
-
-  public var defaultValue: Wrapped.PrimaryKey.QueryOutput?? {
-    Wrapped.columns.primaryKey.defaultValue
   }
 
   public func _aliased<Name: AliasName>(

--- a/Sources/StructuredQueriesCore/QueryDecoder.swift
+++ b/Sources/StructuredQueriesCore/QueryDecoder.swift
@@ -98,10 +98,19 @@ extension QueryDecoder {
 
   @inlinable
   @inline(__always)
-  public mutating func decode<Root, Value: QueryRepresentable<Value>>(
-    _ keyPath: KeyPath<Root, Value>
-  ) throws -> Value? {
-    try decode(Value.self)
+  public mutating func decode<Column: _TableColumnExpression>(
+    _ column: @autoclosure () -> Column
+  ) throws -> Column.Value.QueryOutput? {
+    try Column.Value?(decoder: &self)?.queryOutput
+  }
+
+  @inlinable
+  @inline(__always)
+  public mutating func decode<Column: _TableColumnExpression, Value>(
+    _ column: @autoclosure () -> Column
+  ) throws -> Value.QueryOutput?
+  where Column.Value == Value? {
+    try Value?(decoder: &self)?.queryOutput
   }
 }
 

--- a/Sources/StructuredQueriesCore/TableAlias.swift
+++ b/Sources/StructuredQueriesCore/TableAlias.swift
@@ -226,6 +226,10 @@ where Base.TableColumns: PrimaryKeyedTableDefinition {
       Base.columns.primaryKey._names
     }
 
+    public var defaultValue: Base.PrimaryKey.QueryOutput? {
+      Base.columns.primaryKey.defaultValue
+    }
+
     public var keyPath: KeyPath<TableAlias, Base.PrimaryKey.QueryOutput> {
       \.[member: \Base.PrimaryKey.self, column: Base.columns.primaryKey.keyPath]
     }
@@ -246,10 +250,6 @@ extension TableAlias.TableColumns.PrimaryColumn: TableColumnExpression
 where Base.TableColumns.PrimaryColumn: TableColumnExpression {
   public var name: String {
     Base.columns.primaryKey.name
-  }
-
-  public var defaultValue: Base.PrimaryKey.QueryOutput? {
-    Base.columns.primaryKey.defaultValue
   }
 
   public func _aliased<N: AliasName>(

--- a/Sources/StructuredQueriesCore/TableColumn.swift
+++ b/Sources/StructuredQueriesCore/TableColumn.swift
@@ -4,6 +4,9 @@ public protocol _TableColumnExpression<Root, Value>: QueryExpression where Value
 
   var _names: [String] { get }
 
+  /// The default value of the table column.
+  var defaultValue: Value.QueryOutput? { get }
+
   /// The table model key path associated with this table column.
   var keyPath: KeyPath<Root, Value.QueryOutput> { get }
 }
@@ -16,9 +19,6 @@ public protocol TableColumnExpression<Root, Value>: _TableColumnExpression
 where Value: QueryBindable {
   /// The name of the table column.
   var name: String { get }
-
-  /// The default value of the table column.
-  var defaultValue: Value.QueryOutput? { get }
 
   func _aliased<Name: AliasName>(
     _ alias: Name.Type
@@ -123,10 +123,10 @@ public enum _TableColumn<Root: Table, Value: QueryRepresentable> {
   public static func `for`(
     _: String,
     keyPath: KeyPath<Root, Value>,
-    default _: Value? = nil
+    default defaultValue: Value? = nil
   ) -> ColumnGroup<Root, Value>
   where Value: Table, Value == Value.QueryOutput {
-    ColumnGroup(keyPath: keyPath)
+    ColumnGroup(keyPath: keyPath, default: defaultValue)
   }
 }
 

--- a/Sources/StructuredQueriesMacros/TableMacro.swift
+++ b/Sources/StructuredQueriesMacros/TableMacro.swift
@@ -170,7 +170,6 @@ extension TableMacro: ExtensionMacro {
         var isEphemeral = false
         var isExplicitColumn = false
         var isGenerated = false
-        var hasRepresentation = false
 
         for attribute in property.attributes {
           guard
@@ -219,7 +218,6 @@ extension TableMacro: ExtensionMacro {
 
               columnQueryValueType = "\(raw: base.rewritten(selfRewriter).trimmedDescription)"
               columnQueryOutputType = "\(columnQueryValueType).QueryOutput"
-              hasRepresentation = true
 
             case .some(let label) where label.text == "primaryKey":
               guard
@@ -359,9 +357,7 @@ extension TableMacro: ExtensionMacro {
               : "_TableColumn"
         let tableColumnInitializer = tableColumnType == "_TableColumn" ? ".for" : ""
         let defaultParameter =
-          isColumnGroup
-          ? ""
-          : defaultValue.map { ", default: \($0.trimmedDescription)" } ?? ""
+          defaultValue.map { ", default: \($0.trimmedDescription)" } ?? ""
         func appendColumnProperty(primaryKey: Bool = false) {
           columnsProperties.append(
             """
@@ -383,29 +379,37 @@ extension TableMacro: ExtensionMacro {
           appendColumnProperty(primaryKey: true)
         }
         allColumns.append(identifier)
-        let decodedType = columnQueryValueType?.asNonOptionalType()
-        let decodeArgument = hasRepresentation ? (decodedType.map { "\($0).self" } ?? "") : ""
-        if let defaultValue {
-          decodings.append(
-            """
-            self.\(identifier) = try decoder.decode(\(decodeArgument)) \
-            ?? \(defaultValue)
-            """
-          )
-        } else if columnQueryValueType.map({ $0.isOptionalType }) ?? false {
+        let decodeArgument = "Self.columns.\(identifier)"
+        if columnQueryValueType.map(\.isOptionalType) ?? false {
           decodings.append(
             """
             self.\(identifier) = try decoder.decode(\(decodeArgument))
             """
           )
+          if binding.initializer != nil {
+            decodings.append(
+              """
+              if self.\(identifier) == nil {
+              self.\(identifier) = \(decodeArgument).defaultValue ?? nil
+              }
+              """
+            )
+          }
         } else {
-          let requiredArgument =
-            hasRepresentation ? decodeArgument : "\\QueryValue.\(identifier)"
-          decodings.append(
-            """
-            let \(identifier) = try decoder.decode(\(requiredArgument))
-            """
-          )
+          if binding.initializer != nil {
+            decodings.append(
+              """
+              let \(identifier) = try decoder.decode(\(decodeArgument)) \
+              ?? \(decodeArgument).defaultValue
+              """
+            )
+          } else {
+            decodings.append(
+              """
+              let \(identifier) = try decoder.decode(\(decodeArgument))
+              """
+            )
+          }
           decodingUnwrappings.append(
             """
             guard let \(identifier) else {
@@ -419,7 +423,6 @@ extension TableMacro: ExtensionMacro {
             """
           )
         }
-
       }
       initDecoder = """
 
@@ -574,9 +577,7 @@ extension TableMacro: ExtensionMacro {
             : "_TableColumn"
         let tableColumnInitializer = tableColumnType == "_TableColumn" ? ".for" : ""
         let defaultParameter =
-          isColumnGroup
-          ? ""
-          : defaultValue.map { ", default: \($0.trimmedDescription)" } ?? ""
+          defaultValue.map { ", default: \($0.trimmedDescription)" } ?? ""
         func appendColumnProperty(primaryKey: Bool = false) {
           columnsProperties.append(
             """
@@ -594,10 +595,9 @@ extension TableMacro: ExtensionMacro {
         }
         appendColumnProperty()
         allColumns.append(identifier)
-        let decodedType = columnQueryValueType.asNonOptionalType()
         decodings.append(
           """
-          let \(identifier) = try decoder.decode(\(decodedType).self)
+          let \(identifier) = try decoder.decode(Self.columns.\(identifier)) ?? nil
           """
         )
         let caseArgumentLabel: String
@@ -913,9 +913,7 @@ extension TableMacro: MemberMacro {
               : "_TableColumn"
         let tableColumnInitializer = tableColumnType == "_TableColumn" ? ".for" : ""
         let defaultParameter =
-          isColumnGroup
-          ? ""
-          : defaultValue.map { ", default: \($0.trimmedDescription)" } ?? ""
+          defaultValue.map { ", default: \($0.trimmedDescription)" } ?? ""
         func appendColumnProperty(primaryKey: Bool = false) {
           columnsProperties.append(
             """
@@ -1179,9 +1177,7 @@ extension TableMacro: MemberMacro {
             : "_TableColumn"
         let tableColumnInitializer = tableColumnType == "_TableColumn" ? ".for" : ""
         let defaultParameter =
-          isColumnGroup
-          ? ""
-          : defaultValue.map { ", default: \($0.trimmedDescription)" } ?? ""
+          defaultValue.map { ", default: \($0.trimmedDescription)" } ?? ""
         func appendColumnProperty(primaryKey: Bool = false) {
           columnsProperties.append(
             """

--- a/Tests/StructuredQueriesMacrosTests/LazyInitializableTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/LazyInitializableTests.swift
@@ -165,9 +165,9 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            self.latitude = try decoder.decode() ?? nil
-            self.longitude = try decoder.decode() ?? nil
+            self.id = try decoder.decode(Self.columns.id)
+            self.latitude = try decoder.decode(Self.columns.latitude)
+            self.longitude = try decoder.decode(Self.columns.longitude)
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -178,9 +178,9 @@ extension SnapshotTests {
 
         nonisolated extension Place: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
-            let latitude = try decoder.decode(\QueryValue.latitude)
-            let longitude = try decoder.decode(\QueryValue.longitude)
+            let id = try decoder.decode(Self.columns.id)
+            let latitude = try decoder.decode(Self.columns.latitude)
+            let longitude = try decoder.decode(Self.columns.longitude)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -343,8 +343,8 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            let latitude = try decoder.decode(\QueryValue.latitude)
+            self.id = try decoder.decode(Self.columns.id)
+            let latitude = try decoder.decode(Self.columns.latitude)
             guard let latitude else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -358,8 +358,8 @@ extension SnapshotTests {
 
         nonisolated extension Place: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
-            let latitude = try decoder.decode(\QueryValue.latitude)
+            let id = try decoder.decode(Self.columns.id)
+            let latitude = try decoder.decode(Self.columns.latitude)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -518,8 +518,8 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            self.startsAt = try decoder.decode(Date.ISO8601Representation.self) ?? nil
+            self.id = try decoder.decode(Self.columns.id)
+            self.startsAt = try decoder.decode(Self.columns.startsAt)
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -529,8 +529,8 @@ extension SnapshotTests {
 
         nonisolated extension Event: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
-            let startsAt = try decoder.decode(Date.ISO8601Representation.self)
+            let id = try decoder.decode(Self.columns.id)
+            let startsAt = try decoder.decode(Self.columns.startsAt)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -613,7 +613,7 @@ extension SnapshotTests {
             public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = Draft
               public let id = StructuredQueriesCore._TableColumn<QueryValue, Int?>.for("id", keyPath: \QueryValue.id, default: nil)
-              public let coordinate = StructuredQueriesCore.ColumnGroup<QueryValue, Coordinate?>(keyPath: \QueryValue.coordinate)
+              public let coordinate = StructuredQueriesCore.ColumnGroup<QueryValue, Coordinate?>(keyPath: \QueryValue.coordinate, default: nil)
               #if compiler(>=6.4)
               @_optimize(none)
               #endif
@@ -689,8 +689,8 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            self.coordinate = try decoder.decode() ?? nil
+            self.id = try decoder.decode(Self.columns.id)
+            self.coordinate = try decoder.decode(Self.columns.coordinate)
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -700,8 +700,8 @@ extension SnapshotTests {
 
         nonisolated extension Place: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
-            let coordinate = try decoder.decode(\QueryValue.coordinate)
+            let id = try decoder.decode(Self.columns.id)
+            let coordinate = try decoder.decode(Self.columns.coordinate)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -860,8 +860,8 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            let systemFields = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
+            self.id = try decoder.decode(Self.columns.id)
+            let systemFields = try decoder.decode(Self.columns.systemFields)
             guard let systemFields else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -875,8 +875,8 @@ extension SnapshotTests {
 
         nonisolated extension Record: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
-            let systemFields = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
+            let id = try decoder.decode(Self.columns.id)
+            let systemFields = try decoder.decode(Self.columns.systemFields)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1099,10 +1099,10 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            self.a = try decoder.decode() ?? nil
-            self.b = try decoder.decode() ?? nil
-            self.c = try decoder.decode() ?? nil
+            self.id = try decoder.decode(Self.columns.id)
+            self.a = try decoder.decode(Self.columns.a)
+            self.b = try decoder.decode(Self.columns.b)
+            self.c = try decoder.decode(Self.columns.c)
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -1114,10 +1114,10 @@ extension SnapshotTests {
 
         nonisolated extension Record: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
-            self.a = try decoder.decode() ?? nil
-            self.b = try decoder.decode() ?? nil
-            let c = try decoder.decode(\QueryValue.c)
+            let id = try decoder.decode(Self.columns.id)
+            self.a = try decoder.decode(Self.columns.a)
+            self.b = try decoder.decode(Self.columns.b)
+            let c = try decoder.decode(Self.columns.c)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1290,9 +1290,9 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.latitude = try decoder.decode() ?? nil
-            self.longitude = try decoder.decode() ?? nil
-            let name = try decoder.decode(\QueryValue.name)
+            self.latitude = try decoder.decode(Self.columns.latitude)
+            self.longitude = try decoder.decode(Self.columns.longitude)
+            let name = try decoder.decode(Self.columns.name)
             guard let name else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1307,9 +1307,9 @@ extension SnapshotTests {
 
         nonisolated extension Location: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let latitude = try decoder.decode(\QueryValue.latitude)
-            let longitude = try decoder.decode(\QueryValue.longitude)
-            let name = try decoder.decode(\QueryValue.name)
+            let latitude = try decoder.decode(Self.columns.latitude)
+            let longitude = try decoder.decode(Self.columns.longitude)
+            let name = try decoder.decode(Self.columns.name)
             guard let latitude else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -3191,14 +3191,18 @@ extension SnapshotTests {
 
           nonisolated extension Draft {
             nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              self.id = try decoder.decode() ?? nil
-              let latitude = try decoder.decode(\QueryValue.latitude)
-              self.name = try decoder.decode() ?? ""
-              self.note = try decoder.decode() ?? nil
+              self.id = try decoder.decode(Self.columns.id)
+              let latitude = try decoder.decode(Self.columns.latitude)
+              let name = try decoder.decode(Self.columns.name) ?? Self.columns.name.defaultValue
+              self.note = try decoder.decode(Self.columns.note)
               guard let latitude else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
+              guard let name else {
+                throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+              }
               self.latitude = latitude
+              self.name = name
             }
             nonisolated init(_ other: SourceTable) {
               self.id = other.id
@@ -3210,18 +3214,22 @@ extension SnapshotTests {
 
           nonisolated extension Place: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              let id = try decoder.decode(\QueryValue.id)
-              let latitude = try decoder.decode(\QueryValue.latitude)
-              self.name = try decoder.decode() ?? ""
-              self.note = try decoder.decode() ?? nil
+              let id = try decoder.decode(Self.columns.id)
+              let latitude = try decoder.decode(Self.columns.latitude)
+              let name = try decoder.decode(Self.columns.name) ?? Self.columns.name.defaultValue
+              self.note = try decoder.decode(Self.columns.note)
               guard let id else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
               guard let latitude else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
+              guard let name else {
+                throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+              }
               self.id = id
               self.latitude = latitude
+              self.name = name
             }
           }
           """#
@@ -3390,9 +3398,9 @@ extension SnapshotTests {
 
           nonisolated extension Draft {
             nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              self.id = try decoder.decode() ?? nil
-              let quantity = try decoder.decode(\QueryValue.quantity)
-              self.note = try decoder.decode() ?? nil
+              self.id = try decoder.decode(Self.columns.id)
+              let quantity = try decoder.decode(Self.columns.quantity)
+              self.note = try decoder.decode(Self.columns.note)
               guard let quantity else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -3407,9 +3415,9 @@ extension SnapshotTests {
 
           nonisolated extension Item: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              let id = try decoder.decode(\QueryValue.id)
-              let quantity = try decoder.decode(\QueryValue.quantity)
-              self.note = try decoder.decode() ?? nil
+              let id = try decoder.decode(Self.columns.id)
+              let quantity = try decoder.decode(Self.columns.quantity)
+              self.note = try decoder.decode(Self.columns.note)
               guard let id else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -3592,9 +3600,12 @@ extension SnapshotTests {
 
           nonisolated extension Draft {
             nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              self.id = try decoder.decode() ?? nil
-              self.email = try decoder.decode() ?? ""
-              let age = try decoder.decode(\QueryValue.age)
+              self.id = try decoder.decode(Self.columns.id)
+              self.email = try decoder.decode(Self.columns.email)
+              if self.email == nil {
+                self.email = Self.columns.email.defaultValue ?? nil
+              }
+              let age = try decoder.decode(Self.columns.age)
               guard let age else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -3609,9 +3620,12 @@ extension SnapshotTests {
 
           nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              let id = try decoder.decode(\QueryValue.id)
-              self.email = try decoder.decode() ?? ""  // TODO: Should this be non-optional?
-              let age = try decoder.decode(\QueryValue.age)
+              let id = try decoder.decode(Self.columns.id)
+              self.email = try decoder.decode(Self.columns.email)
+              if self.email == nil {
+                self.email = Self.columns.email.defaultValue ?? nil
+              }
+              let age = try decoder.decode(Self.columns.age)
               guard let id else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -3778,8 +3792,8 @@ extension SnapshotTests {
 
           nonisolated extension Draft {
             nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              self.id = try decoder.decode() ?? nil
-              let name = try decoder.decode(\QueryValue.name)
+              self.id = try decoder.decode(Self.columns.id)
+              let name = try decoder.decode(Self.columns.name)
               guard let name else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -3793,9 +3807,9 @@ extension SnapshotTests {
 
           nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              let id = try decoder.decode(\QueryValue.id)
-              let name = try decoder.decode(\QueryValue.name)
-              let generated = try decoder.decode(\QueryValue.generated)
+              let id = try decoder.decode(Self.columns.id)
+              let name = try decoder.decode(Self.columns.name)
+              let generated = try decoder.decode(Self.columns.generated)
               guard let id else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -3961,8 +3975,8 @@ extension SnapshotTests {
 
           nonisolated extension Draft {
             nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              self.id = try decoder.decode() ?? nil
-              let name = try decoder.decode(\QueryValue.name)
+              self.id = try decoder.decode(Self.columns.id)
+              let name = try decoder.decode(Self.columns.name)
               guard let name else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -3976,8 +3990,8 @@ extension SnapshotTests {
 
           nonisolated extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              let id = try decoder.decode(\QueryValue.id)
-              let name = try decoder.decode(\QueryValue.name)
+              let id = try decoder.decode(Self.columns.id)
+              let name = try decoder.decode(Self.columns.name)
               guard let id else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -4145,8 +4159,8 @@ extension SnapshotTests {
 
           nonisolated extension Draft {
             nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              self.id = try decoder.decode() ?? nil
-              let name = try decoder.decode(\QueryValue.name)
+              self.id = try decoder.decode(Self.columns.id)
+              let name = try decoder.decode(Self.columns.name)
               guard let name else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -4160,8 +4174,8 @@ extension SnapshotTests {
 
           nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              let id = try decoder.decode(\QueryValue.id)
-              let name = try decoder.decode(\QueryValue.name)
+              let id = try decoder.decode(Self.columns.id)
+              let name = try decoder.decode(Self.columns.name)
               guard let id else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -4337,9 +4351,9 @@ extension SnapshotTests {
 
           nonisolated extension Draft {
             fileprivate nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              self.reminderID = try decoder.decode() ?? nil
-              let reminderTitle = try decoder.decode(\QueryValue.reminderTitle)
-              let remindersListTitle = try decoder.decode(\QueryValue.remindersListTitle)
+              self.reminderID = try decoder.decode(Self.columns.reminderID)
+              let reminderTitle = try decoder.decode(Self.columns.reminderTitle)
+              let remindersListTitle = try decoder.decode(Self.columns.remindersListTitle)
               guard let reminderTitle else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -4358,9 +4372,9 @@ extension SnapshotTests {
 
           nonisolated extension ReminderWithList: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              let reminderID = try decoder.decode(\QueryValue.reminderID)
-              let reminderTitle = try decoder.decode(\QueryValue.reminderTitle)
-              let remindersListTitle = try decoder.decode(\QueryValue.remindersListTitle)
+              let reminderID = try decoder.decode(Self.columns.reminderID)
+              let reminderTitle = try decoder.decode(Self.columns.reminderTitle)
+              let remindersListTitle = try decoder.decode(Self.columns.remindersListTitle)
               guard let reminderID else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -4524,8 +4538,8 @@ extension SnapshotTests {
 
           nonisolated extension Draft {
             fileprivate nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              self.id = try decoder.decode() ?? nil
-              let userModificationDate = try decoder.decode(\QueryValue.userModificationDate)
+              self.id = try decoder.decode(Self.columns.id)
+              let userModificationDate = try decoder.decode(Self.columns.userModificationDate)
               guard let userModificationDate else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -4539,8 +4553,8 @@ extension SnapshotTests {
 
           nonisolated extension Metadata: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              let id = try decoder.decode(\QueryValue.id)
-              let userModificationDate = try decoder.decode(\QueryValue.userModificationDate)
+              let id = try decoder.decode(Self.columns.id)
+              let userModificationDate = try decoder.decode(Self.columns.userModificationDate)
               guard let id else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -4698,8 +4712,8 @@ extension SnapshotTests {
 
           nonisolated extension Draft {
             fileprivate nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              self.id = try decoder.decode() ?? nil
-              let timestamps = try decoder.decode(\QueryValue.timestamps)
+              self.id = try decoder.decode(Self.columns.id)
+              let timestamps = try decoder.decode(Self.columns.timestamps)
               guard let timestamps else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }
@@ -4713,8 +4727,8 @@ extension SnapshotTests {
 
           nonisolated extension Row: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
             public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-              let id = try decoder.decode(\QueryValue.id)
-              let timestamps = try decoder.decode(\QueryValue.timestamps)
+              let id = try decoder.decode(Self.columns.id)
+              let timestamps = try decoder.decode(Self.columns.timestamps)
               guard let id else {
                 throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
               }

--- a/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
+++ b/Tests/StructuredQueriesMacrosTests/TableMacroTests.swift
@@ -76,7 +76,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let bar = try decoder.decode(\QueryValue.bar)
+            let bar = try decoder.decode(Self.columns.bar)
             guard let bar else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -158,7 +158,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore._Selection, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let bar = try decoder.decode(\QueryValue.bar)
+            let bar = try decoder.decode(Self.columns.bar)
             guard let bar else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -278,7 +278,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let bar = try decoder.decode(\QueryValue.bar)
+            let bar = try decoder.decode(Self.columns.bar)
             guard let bar else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -402,7 +402,7 @@ extension SnapshotTests {
 
         nonisolated extension Bar: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let baz = try decoder.decode(\QueryValue.baz)
+            let baz = try decoder.decode(Self.columns.baz)
             guard let baz else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -551,10 +551,26 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.c1 = try decoder.decode() ?? true
-            self.c2 = try decoder.decode() ?? 1
-            self.c3 = try decoder.decode() ?? 1.2
-            self.c4 = try decoder.decode() ?? ""
+            let c1 = try decoder.decode(Self.columns.c1) ?? Self.columns.c1.defaultValue
+            let c2 = try decoder.decode(Self.columns.c2) ?? Self.columns.c2.defaultValue
+            let c3 = try decoder.decode(Self.columns.c3) ?? Self.columns.c3.defaultValue
+            let c4 = try decoder.decode(Self.columns.c4) ?? Self.columns.c4.defaultValue
+            guard let c1 else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            guard let c2 else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            guard let c3 else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            guard let c4 else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            self.c1 = c1
+            self.c2 = c2
+            self.c3 = c3
+            self.c4 = c4
           }
         }
         """#
@@ -632,7 +648,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let bar = try decoder.decode(\QueryValue.bar)
+            let bar = try decoder.decode(Self.columns.bar)
             guard let bar else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -758,7 +774,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let bar = try decoder.decode(Date.UnixTimeRepresentation.self)
+            let bar = try decoder.decode(Self.columns.bar)
             guard let bar else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -847,8 +863,8 @@ extension SnapshotTests {
 
         nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let name = try decoder.decode(\QueryValue.name)
-            let generated = try decoder.decode(\QueryValue.generated)
+            let name = try decoder.decode(Self.columns.name)
+            let generated = try decoder.decode(Self.columns.generated)
             guard let name else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -960,8 +976,8 @@ extension SnapshotTests {
 
         nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let name = try decoder.decode(\QueryValue.name)
-            let generated = try decoder.decode(\QueryValue.generated)
+            let name = try decoder.decode(Self.columns.name)
+            let generated = try decoder.decode(Self.columns.generated)
             guard let name else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1049,7 +1065,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let bar = try decoder.decode(\QueryValue.bar)
+            let bar = try decoder.decode(Self.columns.bar)
             guard let bar else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1133,7 +1149,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let bar = try decoder.decode(\QueryValue.bar)
+            let bar = try decoder.decode(Self.columns.bar)
             guard let bar else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1215,7 +1231,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let `bar` = try decoder.decode(\QueryValue.`bar`)
+            let `bar` = try decoder.decode(Self.columns.`bar`)
             guard let `bar` else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1297,7 +1313,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let bar = try decoder.decode(\QueryValue.bar)
+            let bar = try decoder.decode(Self.columns.bar)
             guard let bar else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1379,7 +1395,11 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.bar = try decoder.decode() ?? ID<Foo>()
+            let bar = try decoder.decode(Self.columns.bar) ?? Self.columns.bar.defaultValue
+            guard let bar else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            self.bar = bar
           }
         }
         """#
@@ -1529,8 +1549,8 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode(ID<User, UUID.BytesRepresentation>.self) ?? nil
-            self.referrerID = try decoder.decode(ID<User, UUID.BytesRepresentation>.self) ?? nil
+            self.id = try decoder.decode(Self.columns.id)
+            self.referrerID = try decoder.decode(Self.columns.referrerID)
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -1540,8 +1560,8 @@ extension SnapshotTests {
 
         nonisolated extension User: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(ID<User, UUID.BytesRepresentation>.self)
-            self.referrerID = try decoder.decode(ID<User, UUID.BytesRepresentation>.self) ?? nil
+            let id = try decoder.decode(Self.columns.id)
+            self.referrerID = try decoder.decode(Self.columns.referrerID)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1625,7 +1645,7 @@ extension SnapshotTests {
 
         nonisolated extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let name = try decoder.decode(\QueryValue.name)
+            let name = try decoder.decode(Self.columns.name)
             guard let name else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -1780,8 +1800,12 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            self.seconds = try decoder.decode() ?? 60 * 5
+            self.id = try decoder.decode(Self.columns.id)
+            let seconds = try decoder.decode(Self.columns.seconds) ?? Self.columns.seconds.defaultValue
+            guard let seconds else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            self.seconds = seconds
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -1791,12 +1815,16 @@ extension SnapshotTests {
 
         nonisolated extension SyncUp: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
-            self.seconds = try decoder.decode() ?? 60 * 5
+            let id = try decoder.decode(Self.columns.id)
+            let seconds = try decoder.decode(Self.columns.seconds) ?? Self.columns.seconds.defaultValue
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
+            guard let seconds else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
             self.id = id
+            self.seconds = seconds
           }
         }
         """#
@@ -1964,9 +1992,17 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            self.color = try decoder.decode(Color.HexRepresentation.self) ?? Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255)
-            self.name = try decoder.decode() ?? ""
+            self.id = try decoder.decode(Self.columns.id)
+            let color = try decoder.decode(Self.columns.color) ?? Self.columns.color.defaultValue
+            let name = try decoder.decode(Self.columns.name) ?? Self.columns.name.defaultValue
+            guard let color else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            guard let name else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            self.color = color
+            self.name = name
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -1977,13 +2013,21 @@ extension SnapshotTests {
 
         nonisolated extension RemindersList: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
-            self.color = try decoder.decode(Color.HexRepresentation.self) ?? Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255)
-            self.name = try decoder.decode() ?? ""
+            let id = try decoder.decode(Self.columns.id)
+            let color = try decoder.decode(Self.columns.color) ?? Self.columns.color.defaultValue
+            let name = try decoder.decode(Self.columns.name) ?? Self.columns.name.defaultValue
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
+            guard let color else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            guard let name else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
             self.id = id
+            self.color = color
+            self.name = name
           }
         }
         """#
@@ -2084,7 +2128,7 @@ extension SnapshotTests {
 
       nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
         public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-          let name = try decoder.decode(\QueryValue.name)
+          let name = try decoder.decode(Self.columns.name)
           guard let name else {
             throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
           }
@@ -2175,8 +2219,8 @@ extension SnapshotTests {
 
       nonisolated extension RemindersListAliasAndReminderCount: StructuredQueriesCore.Table, StructuredQueriesCore._Selection, StructuredQueriesCore.PartialSelectStatement {
         public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-          let remindersList = try decoder.decode(TableAlias<RemindersList, RL>.self)
-          let remindersCount = try decoder.decode(\QueryValue.remindersCount)
+          let remindersList = try decoder.decode(Self.columns.remindersList)
+          let remindersCount = try decoder.decode(Self.columns.remindersCount)
           guard let remindersList else {
             throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
           }
@@ -2316,8 +2360,8 @@ extension SnapshotTests {
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let photo = try decoder.decode(Photo.self)
-            let note = try decoder.decode(String.self)
+            let photo = try decoder.decode(Self.columns.photo) ?? nil
+            let note = try decoder.decode(Self.columns.note) ?? nil
             if let photo {
               self = .photo(photo)
             } else if let note {
@@ -2457,8 +2501,8 @@ extension SnapshotTests {
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let photo = try decoder.decode(Photo.self)
-            let note = try decoder.decode(String.self)
+            let photo = try decoder.decode(Self.columns.photo) ?? nil
+            let note = try decoder.decode(Self.columns.note) ?? nil
             if let photo {
               self = .photo(photo)
             } else if let note {
@@ -2597,8 +2641,8 @@ extension SnapshotTests {
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let photo = try decoder.decode(Photo.self)
-            let note = try decoder.decode(String.self)
+            let photo = try decoder.decode(Self.columns.photo) ?? nil
+            let note = try decoder.decode(Self.columns.note) ?? nil
             if let photo {
               self = .photo(photo)
             } else if let note {
@@ -2738,8 +2782,8 @@ extension SnapshotTests {
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let photo = try decoder.decode(Photo.self)
-            let note = try decoder.decode(String.self)
+            let photo = try decoder.decode(Self.columns.photo) ?? nil
+            let note = try decoder.decode(Self.columns.note) ?? nil
             if let photo {
               self = .photo(photo)
             } else if let note {
@@ -2853,7 +2897,7 @@ extension SnapshotTests {
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let note = try decoder.decode(String.self)
+            let note = try decoder.decode(Self.columns.note) ?? nil
             if let note {
               self = .note(text: note)
             } else {
@@ -2965,7 +3009,7 @@ extension SnapshotTests {
 
         nonisolated extension Post: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let timestamp = try decoder.decode(Date.UnixTimeRepresentation.self)
+            let timestamp = try decoder.decode(Self.columns.timestamp) ?? nil
             if let timestamp {
               self = .timestamp(timestamp)
             } else {
@@ -3129,7 +3173,7 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
+            self.id = try decoder.decode(Self.columns.id)
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -3138,7 +3182,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
+            let id = try decoder.decode(Self.columns.id)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -3251,7 +3295,7 @@ extension SnapshotTests {
 
         nonisolated extension Foo.Draft {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
+            let id = try decoder.decode(Self.columns.id)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -3443,10 +3487,14 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            self.title = try decoder.decode() ?? ""
-            self.date = try decoder.decode(Date.UnixTimeRepresentation.self) ?? nil
-            self.priority = try decoder.decode() ?? nil
+            self.id = try decoder.decode(Self.columns.id)
+            let title = try decoder.decode(Self.columns.title) ?? Self.columns.title.defaultValue
+            self.date = try decoder.decode(Self.columns.date)
+            self.priority = try decoder.decode(Self.columns.priority)
+            guard let title else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            self.title = title
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -3458,14 +3506,18 @@ extension SnapshotTests {
 
         nonisolated extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
-            self.title = try decoder.decode() ?? ""
-            self.date = try decoder.decode(Date.UnixTimeRepresentation.self) ?? nil
-            self.priority = try decoder.decode() ?? nil
+            let id = try decoder.decode(Self.columns.id)
+            let title = try decoder.decode(Self.columns.title) ?? Self.columns.title.defaultValue
+            self.date = try decoder.decode(Self.columns.date)
+            self.priority = try decoder.decode(Self.columns.priority)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
+            guard let title else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
             self.id = id
+            self.title = title
           }
         }
         """#
@@ -3599,7 +3651,7 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode(UUID.BytesRepresentation.self) ?? nil
+            self.id = try decoder.decode(Self.columns.id)
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -3608,7 +3660,7 @@ extension SnapshotTests {
 
         nonisolated extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(UUID.BytesRepresentation.self)
+            let id = try decoder.decode(Self.columns.id)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -3690,7 +3742,7 @@ extension SnapshotTests {
 
         nonisolated extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
+            let id = try decoder.decode(Self.columns.id)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }
@@ -3846,8 +3898,12 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            self.title = try decoder.decode() ?? ""
+            self.id = try decoder.decode(Self.columns.id)
+            let title = try decoder.decode(Self.columns.title) ?? Self.columns.title.defaultValue
+            guard let title else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            self.title = title
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -3857,8 +3913,12 @@ extension SnapshotTests {
 
         nonisolated extension Reminder: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
-            self.title = try decoder.decode() ?? ""
+            self.id = try decoder.decode(Self.columns.id)
+            let title = try decoder.decode(Self.columns.title) ?? Self.columns.title.defaultValue
+            guard let title else {
+              throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
+            }
+            self.title = title
           }
         }
         """#
@@ -3922,7 +3982,7 @@ extension SnapshotTests {
 
             public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
               public typealias QueryValue = Draft
-              public let id = StructuredQueriesCore.ColumnGroup<QueryValue, ReminderTagID?>(keyPath: \QueryValue.id)
+              public let id = StructuredQueriesCore.ColumnGroup<QueryValue, ReminderTagID?>(keyPath: \QueryValue.id, default: nil)
               #if compiler(>=6.4)
               @_optimize(none)
               #endif
@@ -3992,7 +4052,7 @@ extension SnapshotTests {
 
         nonisolated extension Draft {
           nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            self.id = try decoder.decode() ?? nil
+            self.id = try decoder.decode(Self.columns.id)
           }
           nonisolated init(_ other: SourceTable) {
             self.id = other.id
@@ -4001,7 +4061,7 @@ extension SnapshotTests {
 
         nonisolated extension ReminderTag: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable, StructuredQueriesCore.PartialSelectStatement {
           public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-            let id = try decoder.decode(\QueryValue.id)
+            let id = try decoder.decode(Self.columns.id)
             guard let id else {
               throw StructuredQueriesCore.QueryDecodingError.missingRequiredColumn
             }

--- a/Tests/StructuredQueriesTests/CompileTimeTests.swift
+++ b/Tests/StructuredQueriesTests/CompileTimeTests.swift
@@ -96,6 +96,46 @@ private func functionWithLotsOfArguments(
 ) {
 }
 
+@Table
+private struct TableWithNestedRepresentation {
+  struct Nested: Codable, Equatable {
+    var x = 0
+  }
+
+  enum Status: Int, QueryBindable {
+    case active, archived
+  }
+
+  let id: Int
+
+  @Column(as: Nested.JSONRepresentation.self)
+  var nested: Nested
+
+  @Column(as: Nested.JSONRepresentation.self)
+  var nestedWithDefault: Nested = Nested(x: 1)
+
+  var status: Status = Status.active
+}
+private func nestedRepresentationDraft() {
+  _ = TableWithNestedRepresentation.Draft(nested: TableWithNestedRepresentation.Nested())
+}
+private enum Namespace {
+  struct Sibling: Codable, Equatable {
+    var y = 0
+  }
+
+  @Table
+  struct TableWithSiblingRepresentation {
+    let id: Int
+
+    @Column(as: Sibling.JSONRepresentation.self)
+    var sibling: Sibling
+  }
+}
+private func siblingRepresentationDraft() {
+  _ = Namespace.TableWithSiblingRepresentation.Draft(sibling: Namespace.Sibling())
+}
+
 // NB: Nested access control mismatch
 @Table
 private struct Item {


### PR DESCRIPTION
Moving draft initializers to an extension means these types no longer resolve without qualification.

We can introduce `decode` and `defaultValue` helpers to allow the type information flow implicitly.

Fixes #314.